### PR TITLE
Continuous builds for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,17 @@ script:
   - sudo make install
   - sudo ldconfig
   - cd ../..
-  - qmake PREFIX=/usr
+  - mkdir build
+  - cd build
+  - qmake PREFIX=/usr ..
   - make -j4
   - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/ # "make install" seems not implemented
-  - find build
-  - mkdir -p appdir/usr/share/applications
-  - mkdir -p appdir/usr/bin
-  - mkdir -p appdir/usr/lib
-  - mkdir -p appdir/usr/share/icons/hicolor/512x512/apps/
+  - cd ..
+  - find build/
+  - mkdir -p ./appdir/usr/share/applications
+  - mkdir -p ./appdir/usr/bin
+  - mkdir -p ./appdir/usr/lib
+  - mkdir -p ./appdir/usr/share/icons/hicolor/512x512/apps/
   - cp icon.png appdir/usr/share/icons/hicolor/512x512/apps/welleio.png
   
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,12 @@ sudo: require
 dist: trusty
 
 before_install:
-#    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install g++-6 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
-#    - export CXX=g++-6
-#    - export CC=gcc-6
 
 script:
   - # https://github.com/AlbrechtL/welle.io/issues/32#issuecomment-289561703

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ after_success:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./WelleIO*.AppImage https://transfer.sh/WelleIO-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl --upload-file ./welle*.AppImage https://transfer.sh/welle_io-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
   - cd ..
   - find build/
   - mkdir -p ./appdir/usr/share/applications
-  - welle-io.desktop ./appdir/usr/share/applications
+  - cp welle-io.desktop ./appdir/usr/share/applications
   - mkdir -p ./appdir/usr/bin
   - cp build/welle-io ./appdir/usr/bin
   - mkdir -p ./appdir/usr/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,21 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:
+  - # https://github.com/airspy/airspyone_host#how-to-build-the-host-software-on-linux
+  - wget https://github.com/airspy/host/archive/master.zip
+  - unzip master.zip
+  - cd host-master
+  - mkdir build
+  - cd build
+  - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
+  - make
+  - sudo make install
+  - sudo ldconfig
+  - cd ..
   - qmake PREFIX=/usr
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - cd host-master
   - mkdir build
   - cd build
-  - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake ../ -DINSTALL_UDEV_RULES=ON # -DCMAKE_INSTALL_PREFIX=/usr
   - make
   - sudo make install
   - sudo ldconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,12 @@ script:
   - cd ../..
   - qmake PREFIX=/usr
   - make -j4
-  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cd .. 
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58quickcontrols2 qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58quickcontrols qt58quickcontrols2 qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ install:
     - export CC=gcc-6
 
 script:
+  - # https://github.com/AlbrechtL/welle.io/issues/32#issuecomment-289561703
+  - sed -i -e 's|int16_t Data [fragmentSize] = {0};|int16_t Data [fragmentSize] ;|g' src/backend/audio/dab-audio.cpp
+  - sed -i -e 's|int16_t tempX [fragmentSize] = {0};|int16_t tempX [fragmentSize];|g' src/backend/audio/dab-audio.cpp
   - qmake PREFIX=/usr
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base
+    - sudo apt-get -y install qt58base libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt58base
+    - source /opt/qt58/bin/qt58-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j4
+  - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./WelleIO*.AppImage https://transfer.sh/WelleIO-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,12 @@ script:
   - cd ..
   - find build/
   - mkdir -p ./appdir/usr/share/applications
+  - welle-io.desktop ./appdir/usr/share/applications
   - mkdir -p ./appdir/usr/bin
+  - cp build/welle-io ./appdir/usr/bin
   - mkdir -p ./appdir/usr/lib
   - mkdir -p ./appdir/usr/share/icons/hicolor/512x512/apps/
-  - cp icon.png appdir/usr/share/icons/hicolor/512x512/apps/welleio.png
+  - cp icon.png appdir/usr/share/icons/hicolor/512x512/apps/welle-io.png
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=. -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=. -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./welle*.AppImage https://transfer.sh/welle_io-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - sudo make install
   - find /usr | grep airspy
   - sudo ldconfig
-  - cd ..
+  - cd ../..
   - qmake PREFIX=/usr
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58quickcontrols qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58quickcontrols qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install libusb-1.0-0-dev pkg-config qt58base qt58declarative qt58quickcontrols2 qt58charts-no-lgpl qt58multimedia libpulse0 libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: none
 compiler: gcc
 sudo: require
 dist: trusty
@@ -11,7 +11,8 @@ before_install:
 install: 
     - sudo apt-get -y install g++-5 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
-    - export CXX="g++-5"
+    - export CXX=g++-5
+    - export CC=gcc-5
 
 script:
   - qmake PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ sudo: require
 dist: trusty
 
 before_install:
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+#    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
     - sudo apt-get update -qq
     
 install: 
     - sudo apt-get -y install g++-6 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
-    - export CXX=g++-6
-    - export CC=gcc-6
+#    - export CXX=g++-6
+#    - export CC=gcc-6
 
 script:
   - # https://github.com/AlbrechtL/welle.io/issues/32#issuecomment-289561703

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,17 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install g++-5 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install g++-6 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
-    - export CXX=g++-5
-    - export CC=gcc-5
+    - export CXX=g++-6
+    - export CC=gcc-6
 
 script:
   - qmake PREFIX=/usr
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
+  
+after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - # https://github.com/airspy/airspyone_host#how-to-build-the-host-software-on-linux
   - wget https://github.com/airspy/host/archive/master.zip
   - unzip master.zip
-  - cd host-master
+  - cd airspyone_host-master/
   - mkdir build
   - cd build
   - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install g++-4.8 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install g++-5 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
-    - export CXX="g++-4.8"
+    - export CXX="g++-5"
 
 script:
   - qmake PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ script:
   - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make
   - sudo make install
-  - find /usr | grep airspy
   - sudo ldconfig
   - cd ../..
   - qmake PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
   - cd build
   - qmake PREFIX=/usr ..
   - make -j4
-  - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/ # "make install" seems not implemented
+  - # sudo make INSTALL_ROOT=../appdir install ; sudo chown -R $USER appdir ; find appdir/
+  - # "make install" seems not implemented, hence going though the following steps manually:
   - cd ..
   - find build/
   - mkdir -p ./appdir/usr/share/applications

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-compiler: gcc
+compiler: clang
 sudo: require
 dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: cpp
-compiler: clang
+compiler: gcc
 sudo: require
 dist: trusty
 
 before_install:
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo add-apt-repository ppa:beineri/opt-qt58-trusty -y
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
+    - sudo apt-get -y install g++-4.8 qt58base qt58declarative qt58charts-no-lgpl qt58multimedia libfaad-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev
     - source /opt/qt58/bin/qt58-env.sh
+    - export CXX="g++-4.8"
 
 script:
   - qmake PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,13 @@ script:
   - cd ../..
   - qmake PREFIX=/usr
   - make -j4
-  - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/
-  - sudo apt-get -y install checkinstall
-  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
-  - mkdir appdir ; cd appdir
-  - dpkg -x ../app_1-1_amd64.deb . ; find .
-  - cd .. 
+  - # sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/ # "make install" seems not implemented
+  - find build
+  - mkdir -p appdir/usr/share/applications
+  - mkdir -p appdir/usr/bin
+  - mkdir -p appdir/usr/lib
+  - mkdir -p appdir/usr/share/icons/hicolor/512x512/apps/
+  - cp icon.png appdir/usr/share/icons/hicolor/512x512/apps/welleio.png
   
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ install:
     - source /opt/qt58/bin/qt58-env.sh
 
 script:
-  - # https://github.com/AlbrechtL/welle.io/issues/32#issuecomment-289561703
-  - sed -i -e 's|int16_t Data [fragmentSize] = {0};|int16_t Data [fragmentSize] ;|g' src/backend/audio/dab-audio.cpp
-  - sed -i -e 's|int16_t tempX [fragmentSize] = {0};|int16_t tempX [fragmentSize];|g' src/backend/audio/dab-audio.cpp
   - qmake PREFIX=/usr
   - make -j4
   - sudo make INSTALL_ROOT=appdir install ; sudo chown -R $USER appdir ; find appdir/

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ script:
   - cd host-master
   - mkdir build
   - cd build
-  - cmake ../ -DINSTALL_UDEV_RULES=ON # -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make
   - sudo make install
+  - find /usr | grep airspy
   - sudo ldconfig
   - cd ..
   - qmake PREFIX=/usr

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[welle.io](https://www.welle.io)
+[welle.io](https://www.welle.io) [![Build Status](https://travis-ci.org/AlbrechtL/welle.io.svg?branch=master)](https://travis-ci.org/AlbrechtL/welle.io)
 =====================
 This repository contains the implementation of a simple DAB/DAB+ receiver. 
 It is fork from dab-rpi and sdr-j-dab which is now qt-dab https://github.com/JvanKatwijk/qt-dab.

--- a/src/backend/audio/dab-audio.cpp
+++ b/src/backend/audio/dab-audio.cpp
@@ -127,8 +127,8 @@ int16_t	i, j;
 int16_t	countforInterleaver	= 0;
 int16_t	interleaverIndex	= 0;
 uint8_t	shiftRegister [9];
-int16_t	Data [fragmentSize] = {0};
-int16_t tempX [fragmentSize] = {0};
+int16_t Data [fragmentSize];
+int16_t tempX [fragmentSize];
 
 	while (running) {
 	   while (Buffer -> GetRingBufferReadAvailable () <= fragmentSize) {

--- a/welle-io.desktop
+++ b/welle-io.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=welle.io
+Exec=welle-io
+Icon=welle-io
+Comment=A DAB/DAB+ Software Radio


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed (unlike Snap and Flatpak)
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs (unlike Flatpak)
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.