### PR TITLE
Add the short form Git hash of built changeset in CMake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,9 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-add_definitions("-DGITHASH=\"${GIT_COMMIT_HASH}\"")
+if(GIT_COMMIT_HASH)
+  add_definitions("-DGITHASH=\"${GIT_COMMIT_HASH}\"")
+endif()
 
 add_executable (${executableName} ${sources} ${EXTRA_MOCS} touch_gui_resource.qrc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,15 @@ QT5_WRAP_CPP(EXTRA_MOCS
   src/backend/audio/faad-decoder.h
 )
 
+execute_process(
+  COMMAND git rev-parse --short HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+add_definitions("-DGITHASH=\"${GIT_COMMIT_HASH}\"")
+
 add_executable (${executableName} ${sources} ${EXTRA_MOCS} touch_gui_resource.qrc)
 
 target_link_libraries (${executableName}


### PR DESCRIPTION
Added this to be consistent with the Qt Creator build.