### PR TITLE
Remove automatic playback after RTL-SDR device initialization

### DIFF
--- a/android/java/io/welle/welle/DabService.java
+++ b/android/java/io/welle/welle/DabService.java
@@ -353,9 +353,6 @@ public class DabService extends QtService implements AudioManager.OnAudioFocusCh
 
         // Update state
         updatePlaybackState();
-
-        // Play last station
-        playLastStation();
     }
 
     private void handleDeviceClosed() {


### PR DESCRIPTION
As discussed in:
https://forum.welle.io/discussion/17/disable-autostart-on-boot