### PR TITLE
Add HackRF to supported devices via SoapySDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following SDR devices are supported
 * rtl_tcp (http://osmocom.org/projects/sdr/wiki/rtl-sdr#rtl_tcp)
 * I/Q RAW file (https://www.welle.io/devices/rawfile)
 * The LimeSDR through [SoapySDR](https://github.com/pothosware/SoapySDR) (Connect your antenna to `RX1_W`).
+* The HackRF through [SoapySDR](https://github.com/pothosware/SoapySDR) built with HackRF support
 
 Building
 ====================


### PR DESCRIPTION
If SoapySDR is compiled with support for HackRF, welle.io also works with the HackRF. I've tested it with my own device and searching for stations, tuning and listenting to them worked so far. There might be some bugs, though.