### PR TITLE
Zvpunry/soapysdr commandline options

### DIFF
--- a/src/CRadioController.cpp
+++ b/src/CRadioController.cpp
@@ -31,6 +31,7 @@
 #include <QSettings>
 
 #include "CRadioController.h"
+#include "CSoapySdr.h"
 #include "CInputFactory.h"
 #include "CRAWFile.h"
 #include "CRTL_TCP_Client.h"
@@ -171,6 +172,7 @@ void CRadioController::onEventLoopStarted()
     QString dabDevice = "auto";
 #endif
 
+    QString sdrDriverArgs;
     QString ipAddress = "127.0.0.1";
     uint16_t ipPort = 1234;
     QString rawFile = "";
@@ -178,6 +180,9 @@ void CRadioController::onEventLoopStarted()
 
     if(commandLineOptions["dabDevice"] != "")
         dabDevice = commandLineOptions["dabDevice"].toString();
+
+    if(commandLineOptions["sdr-driver-args"] != "")
+        sdrDriverArgs = commandLineOptions["sdr-driver-args"].toString();
 
     if(commandLineOptions["ipAddress"] != "")
         ipAddress = commandLineOptions["ipAddress"].toString();
@@ -207,6 +212,11 @@ void CRadioController::onEventLoopStarted()
         CRAWFile* RAWFile = (CRAWFile*)Device;
 
         RAWFile->setFileName(rawFile, rawFileFormat);
+    }
+
+    if (Device->getID() == CDeviceID::SOAPYSDR) {
+	CSoapySdr *sdr = (CSoapySdr*)Device;
+	sdr->setDriverArgs(sdrDriverArgs);
     }
 
     Initialise();

--- a/src/CRadioController.cpp
+++ b/src/CRadioController.cpp
@@ -31,7 +31,9 @@
 #include <QSettings>
 
 #include "CRadioController.h"
+#ifdef HAVE_SOAPYSDR
 #include "CSoapySdr.h"
+#endif /* HAVE_SOAPYSDR */
 #include "CInputFactory.h"
 #include "CRAWFile.h"
 #include "CRTL_TCP_Client.h"
@@ -172,9 +174,11 @@ void CRadioController::onEventLoopStarted()
     QString dabDevice = "auto";
 #endif
 
+#ifdef HAVE_SOAPYSDR
     QString sdrDriverArgs;
     QString sdrAntenna;
     QString sdrClockSource;
+#endif /* HAVE_SOAPYSDR */
     QString ipAddress = "127.0.0.1";
     uint16_t ipPort = 1234;
     QString rawFile = "";
@@ -183,6 +187,7 @@ void CRadioController::onEventLoopStarted()
     if(commandLineOptions["dabDevice"] != "")
         dabDevice = commandLineOptions["dabDevice"].toString();
 
+#ifdef HAVE_SOAPYSDR
     if(commandLineOptions["sdr-driver-args"] != "")
         sdrDriverArgs = commandLineOptions["sdr-driver-args"].toString();
 
@@ -191,6 +196,7 @@ void CRadioController::onEventLoopStarted()
 
     if(commandLineOptions["sdr-clock-source"] != "")
         sdrClockSource = commandLineOptions["sdr-clock-source"].toString();
+#endif /* HAVE_SOAPYSDR */
 
     if(commandLineOptions["ipAddress"] != "")
         ipAddress = commandLineOptions["ipAddress"].toString();
@@ -222,6 +228,7 @@ void CRadioController::onEventLoopStarted()
         RAWFile->setFileName(rawFile, rawFileFormat);
     }
 
+#ifdef HAVE_SOAPYSDR
     if (Device->getID() == CDeviceID::SOAPYSDR) {
         CSoapySdr *sdr = (CSoapySdr*)Device;
 
@@ -237,6 +244,7 @@ void CRadioController::onEventLoopStarted()
             sdr->setClockSource(sdrClockSource);
         }
     }
+#endif /* HAVE_SOAPYSDR */
 
     Initialise();
 }

--- a/src/CRadioController.cpp
+++ b/src/CRadioController.cpp
@@ -174,6 +174,7 @@ void CRadioController::onEventLoopStarted()
 
     QString sdrDriverArgs;
     QString sdrAntenna;
+    QString sdrClockSource;
     QString ipAddress = "127.0.0.1";
     uint16_t ipPort = 1234;
     QString rawFile = "";
@@ -187,6 +188,9 @@ void CRadioController::onEventLoopStarted()
 
     if(commandLineOptions["sdr-antenna"] != "")
         sdrAntenna = commandLineOptions["sdr-antenna"].toString();
+
+    if(commandLineOptions["sdr-clock-source"] != "")
+        sdrClockSource = commandLineOptions["sdr-clock-source"].toString();
 
     if(commandLineOptions["ipAddress"] != "")
         ipAddress = commandLineOptions["ipAddress"].toString();
@@ -227,6 +231,10 @@ void CRadioController::onEventLoopStarted()
 
         if (!sdrDriverArgs.isEmpty()) {
             sdr->setAntenna(sdrAntenna);
+        }
+
+        if (!sdrClockSource.isEmpty()) {
+            sdr->setClockSource(sdrClockSource);
         }
     }
 

--- a/src/CRadioController.cpp
+++ b/src/CRadioController.cpp
@@ -173,6 +173,7 @@ void CRadioController::onEventLoopStarted()
 #endif
 
     QString sdrDriverArgs;
+    QString sdrAntenna;
     QString ipAddress = "127.0.0.1";
     uint16_t ipPort = 1234;
     QString rawFile = "";
@@ -183,6 +184,9 @@ void CRadioController::onEventLoopStarted()
 
     if(commandLineOptions["sdr-driver-args"] != "")
         sdrDriverArgs = commandLineOptions["sdr-driver-args"].toString();
+
+    if(commandLineOptions["sdr-antenna"] != "")
+        sdrAntenna = commandLineOptions["sdr-antenna"].toString();
 
     if(commandLineOptions["ipAddress"] != "")
         ipAddress = commandLineOptions["ipAddress"].toString();
@@ -215,8 +219,15 @@ void CRadioController::onEventLoopStarted()
     }
 
     if (Device->getID() == CDeviceID::SOAPYSDR) {
-	CSoapySdr *sdr = (CSoapySdr*)Device;
-	sdr->setDriverArgs(sdrDriverArgs);
+        CSoapySdr *sdr = (CSoapySdr*)Device;
+
+        if (!sdrDriverArgs.isEmpty()) {
+            sdr->setDriverArgs(sdrDriverArgs);
+        }
+
+        if (!sdrDriverArgs.isEmpty()) {
+            sdr->setAntenna(sdrAntenna);
+        }
     }
 
     Initialise();

--- a/src/input/CSoapySdr.cpp
+++ b/src/input/CSoapySdr.cpp
@@ -59,6 +59,11 @@ void CSoapySdr::setAntenna(QString antenna)
     m_antenna = antenna;
 }
 
+void CSoapySdr::setClockSource(QString clock_source)
+{
+    m_clock_source = clock_source;
+}
+
 void CSoapySdr::setFrequency(int32_t Frequency)
 {
     m_freq = Frequency;
@@ -101,6 +106,9 @@ bool CSoapySdr::restart()
 
     if (!m_antenna.isEmpty())
         m_device->setAntenna(SOAPY_SDR_RX, 0, m_antenna.toStdString());
+
+    if (!m_clock_source.isEmpty())
+        m_device->setClockSource(m_clock_source.toStdString());
 
     if (m_freq > 0) {
         setFrequency(m_freq);

--- a/src/input/CSoapySdr.cpp
+++ b/src/input/CSoapySdr.cpp
@@ -49,6 +49,11 @@ CSoapySdr::~CSoapySdr()
 }
 
 
+void CSoapySdr::setDriverArgs(QString args)
+{
+    m_driver_args = args;
+}
+
 void CSoapySdr::setFrequency(int32_t Frequency)
 {
     m_freq = Frequency;
@@ -70,7 +75,7 @@ bool CSoapySdr::restart()
     m_sampleBuffer.FlushRingBuffer();
     m_spectrumSampleBuffer.FlushRingBuffer();
 
-    m_device = SoapySDR::Device::make();
+    m_device = SoapySDR::Device::make(m_driver_args.toStdString());
     stringstream ss;
     ss << "SoapySDR driver=" << m_device->getDriverKey();
     ss << " hardware=" << m_device->getHardwareKey();

--- a/src/input/CSoapySdr.cpp
+++ b/src/input/CSoapySdr.cpp
@@ -54,6 +54,11 @@ void CSoapySdr::setDriverArgs(QString args)
     m_driver_args = args;
 }
 
+void CSoapySdr::setAntenna(QString antenna)
+{
+    m_antenna = antenna;
+}
+
 void CSoapySdr::setFrequency(int32_t Frequency)
 {
     m_freq = Frequency;
@@ -94,7 +99,8 @@ bool CSoapySdr::restart()
         m_device->getSampleRate(SOAPY_SDR_RX, 0) / 1000.0 <<
         " ksps.";
 
-    m_device->setAntenna(SOAPY_SDR_RX, 0, "LNAW");
+    if (!m_antenna.isEmpty())
+        m_device->setAntenna(SOAPY_SDR_RX, 0, m_antenna.toStdString());
 
     if (m_freq > 0) {
         setFrequency(m_freq);

--- a/src/input/CSoapySdr.h
+++ b/src/input/CSoapySdr.h
@@ -63,12 +63,14 @@ public:
     virtual CDeviceID getID(void);
     virtual void setDriverArgs(QString args);
     virtual void setAntenna(QString antenna);
+    virtual void setClockSource(QString clock_source);
 private:
     friend class CSoapySdr_Thread;
 
     int32_t m_freq = 0;
     QString m_driver_args;
     QString m_antenna;
+    QString m_clock_source;
     SoapySDR::Device *m_device = nullptr;
     std::atomic<bool> m_running;
     CSoapySdr_Thread *m_thread = nullptr;

--- a/src/input/CSoapySdr.h
+++ b/src/input/CSoapySdr.h
@@ -62,11 +62,13 @@ public:
     virtual QString getName(void);
     virtual CDeviceID getID(void);
     virtual void setDriverArgs(QString args);
+    virtual void setAntenna(QString antenna);
 private:
     friend class CSoapySdr_Thread;
 
     int32_t m_freq = 0;
     QString m_driver_args;
+    QString m_antenna;
     SoapySDR::Device *m_device = nullptr;
     std::atomic<bool> m_running;
     CSoapySdr_Thread *m_thread = nullptr;

--- a/src/input/CSoapySdr.h
+++ b/src/input/CSoapySdr.h
@@ -61,10 +61,12 @@ public:
     virtual void setHwAgc(bool hwAGC);
     virtual QString getName(void);
     virtual CDeviceID getID(void);
+    virtual void setDriverArgs(QString args);
 private:
     friend class CSoapySdr_Thread;
 
     int32_t m_freq = 0;
+    QString m_driver_args;
     SoapySDR::Device *m_device = nullptr;
     std::atomic<bool> m_running;
     CSoapySdr_Thread *m_thread = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,6 +133,11 @@ int main(int argc, char** argv)
         QCoreApplication::translate("main", "args"));
     optionParser.addOption(SDRDriverArgsOption);
 
+    QCommandLineOption SDRAntennaOption("sdr-antenna",
+        QCoreApplication::translate("main", "The value depends on the SDR Hardware, typical values are RX2, TX/RX, LNAW. Just query it with SoapySDRUtil --probe=driver=uhd"),
+        QCoreApplication::translate("main", "antenna"));
+    optionParser.addOption(SDRAntennaOption);
+
     QCommandLineOption DABModeOption("M",
         QCoreApplication::translate("main", "DAB mode. Possible is: 1, 2 or 4, default: 1"),
         QCoreApplication::translate("main", "Mode"));
@@ -196,6 +201,7 @@ int main(int argc, char** argv)
     QVariantMap commandLineOptions;
     commandLineOptions["dabDevice"] = optionParser.value(InputOption);
     commandLineOptions["sdr-driver-args"] = optionParser.value(SDRDriverArgsOption);
+    commandLineOptions["sdr-antenna"] = optionParser.value(SDRAntennaOption);
     commandLineOptions["ipAddress"] = optionParser.value(RTL_TCPServerIPOption);
     commandLineOptions["ipPort"] = optionParser.value(RTL_TCPServerIPPort);
     commandLineOptions["rawFile"] = optionParser.value(RAWFile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,7 @@ int main(int argc, char** argv)
         QCoreApplication::translate("main", "Name"));
     optionParser.addOption(InputOption);
 
+#ifdef HAVE_SOAPYSDR
     QCommandLineOption SDRDriverArgsOption("sdr-driver-args",
         QCoreApplication::translate("main", "The value depends on the SDR driver and is directly passed to it (currently only SoapySDR::Device::make(args)). A typical value for SoapySDR is a string like driver=remote,remote=127.0.0.1,remote:driver=rtlsdr,rtl=0"),
         QCoreApplication::translate("main", "args"));
@@ -142,6 +143,7 @@ int main(int argc, char** argv)
         QCoreApplication::translate("main", "The value depends on the SDR Hardware, typical values are internal, external, gpsdo. Just query it with SoapySDRUtil --probe=driver=uhd"),
         QCoreApplication::translate("main", "clock_source"));
     optionParser.addOption(SDRClockSourceOption);
+#endif /* HAVE_SOAPYSDR */
 
     QCommandLineOption DABModeOption("M",
         QCoreApplication::translate("main", "DAB mode. Possible is: 1, 2 or 4, default: 1"),
@@ -205,9 +207,11 @@ int main(int argc, char** argv)
 
     QVariantMap commandLineOptions;
     commandLineOptions["dabDevice"] = optionParser.value(InputOption);
+#ifdef HAVE_SOAPYSDR
     commandLineOptions["sdr-driver-args"] = optionParser.value(SDRDriverArgsOption);
     commandLineOptions["sdr-antenna"] = optionParser.value(SDRAntennaOption);
     commandLineOptions["sdr-clock-source"] = optionParser.value(SDRClockSourceOption);
+#endif /* HAVE_SOAPYSDR */
     commandLineOptions["ipAddress"] = optionParser.value(RTL_TCPServerIPOption);
     commandLineOptions["ipPort"] = optionParser.value(RTL_TCPServerIPPort);
     commandLineOptions["rawFile"] = optionParser.value(RAWFile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,9 +134,14 @@ int main(int argc, char** argv)
     optionParser.addOption(SDRDriverArgsOption);
 
     QCommandLineOption SDRAntennaOption("sdr-antenna",
-        QCoreApplication::translate("main", "The value depends on the SDR Hardware, typical values are RX2, TX/RX, LNAW. Just query it with SoapySDRUtil --probe=driver=uhd"),
+        QCoreApplication::translate("main", "The value depends on the SDR Hardware, typical values are TX/RX, RX2. Just query it with SoapySDRUtil --probe=driver=uhd"),
         QCoreApplication::translate("main", "antenna"));
     optionParser.addOption(SDRAntennaOption);
+
+    QCommandLineOption SDRClockSourceOption("sdr-clock-source",
+        QCoreApplication::translate("main", "The value depends on the SDR Hardware, typical values are internal, external, gpsdo. Just query it with SoapySDRUtil --probe=driver=uhd"),
+        QCoreApplication::translate("main", "clock_source"));
+    optionParser.addOption(SDRClockSourceOption);
 
     QCommandLineOption DABModeOption("M",
         QCoreApplication::translate("main", "DAB mode. Possible is: 1, 2 or 4, default: 1"),
@@ -202,6 +207,7 @@ int main(int argc, char** argv)
     commandLineOptions["dabDevice"] = optionParser.value(InputOption);
     commandLineOptions["sdr-driver-args"] = optionParser.value(SDRDriverArgsOption);
     commandLineOptions["sdr-antenna"] = optionParser.value(SDRAntennaOption);
+    commandLineOptions["sdr-clock-source"] = optionParser.value(SDRClockSourceOption);
     commandLineOptions["ipAddress"] = optionParser.value(RTL_TCPServerIPOption);
     commandLineOptions["ipPort"] = optionParser.value(RTL_TCPServerIPPort);
     commandLineOptions["rawFile"] = optionParser.value(RAWFile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,11 @@ int main(int argc, char** argv)
         QCoreApplication::translate("main", "Name"));
     optionParser.addOption(InputOption);
 
+    QCommandLineOption SDRDriverArgsOption("sdr-driver-args",
+        QCoreApplication::translate("main", "The value depends on the SDR driver and is directly passed to it (currently only SoapySDR::Device::make(args)). A typical value for SoapySDR is a string like driver=remote,remote=127.0.0.1,remote:driver=rtlsdr,rtl=0"),
+        QCoreApplication::translate("main", "args"));
+    optionParser.addOption(SDRDriverArgsOption);
+
     QCommandLineOption DABModeOption("M",
         QCoreApplication::translate("main", "DAB mode. Possible is: 1, 2 or 4, default: 1"),
         QCoreApplication::translate("main", "Mode"));
@@ -190,6 +195,7 @@ int main(int argc, char** argv)
 
     QVariantMap commandLineOptions;
     commandLineOptions["dabDevice"] = optionParser.value(InputOption);
+    commandLineOptions["sdr-driver-args"] = optionParser.value(SDRDriverArgsOption);
     commandLineOptions["ipAddress"] = optionParser.value(RTL_TCPServerIPOption);
     commandLineOptions["ipPort"] = optionParser.value(RTL_TCPServerIPPort);
     commandLineOptions["rawFile"] = optionParser.value(RAWFile);


### PR DESCRIPTION
This adds three command line options, "--sdr-driver-args", "--sdr-antenna", "--sdr-clock-source". It also removes the hard-coded antenna and therefore avoids the exception that is thrown by any SDR-driver 
that allows antenna-selection and doesn't have an antenna called "LNAW".

The LNAW antenna seems to be the receive antenna of a limesdr. This patch will break the expected behavior of users with that SDR with the antenna on the LNAW port, but that is the risk if you use hard-coded hacks. They may disappear at some time.