### PR TITLE
[RTL_TCP] Add "set gain mode 1"

### DIFF
--- a/src/input/CRTL_TCP_Client.cpp
+++ b/src/input/CRTL_TCP_Client.cpp
@@ -353,6 +353,8 @@ void CRTL_TCP_Client::TCPConnectionWatchDogTimeout()
             qDebug() << "RTL_TCP_CLIENT:" << "Successful connected to server";
             connected	= true;
 
+            setGainMode(isHwAGC ? 1 : 0);
+
             setHwAgc(isHwAGC);
 
             if(isAGC)


### PR DESCRIPTION
This patch enables the AGC in the TUNER chip when using the RTL_TCP client.