### PR TITLE
Consistent View sizes

### DIFF
--- a/src/gui/QML/main.qml
+++ b/src/gui/QML/main.qml
@@ -318,7 +318,8 @@ ApplicationWindow {
 
         Loader {
             id: stationView
-            Layout.minimumWidth: Units.dp(350)
+            Layout.minimumWidth: Units.dp(150)
+            Layout.preferredWidth: Units.dp(300)
             Layout.margins: Units.dp(10)
             sourceComponent: channelBrowser
         }
@@ -333,7 +334,8 @@ ApplicationWindow {
 
             Loader {
                 id: stationView
-                Layout.minimumWidth: Units.dp(350)
+                Layout.minimumWidth: Units.dp(150)
+                Layout.preferredWidth: Units.dp(300)
                 Layout.margins: Units.dp(10)
                 sourceComponent: channelBrowser
             }
@@ -361,12 +363,14 @@ ApplicationWindow {
 
             Loader {
                 id: stationView
-                Layout.minimumWidth: Units.dp(300)
+                Layout.minimumWidth: Units.dp(150)
+                Layout.preferredWidth: Units.dp(300)
                 Layout.margins: Units.dp(10)
                 sourceComponent: stackViewMain
             }
             Loader {
                 id: radioInformationViewLoader
+                Layout.minimumWidth: Units.dp(50)
                 Layout.preferredWidth: Units.dp(400)
                 Layout.margins: Units.dp(10)
                 sourceComponent: radioInformationView
@@ -388,18 +392,21 @@ ApplicationWindow {
 
             Loader {
                 id: stationView
-                Layout.minimumWidth: Units.dp(300)
+                Layout.minimumWidth: Units.dp(150)
+                Layout.preferredWidth: Units.dp(300)
                 Layout.margins: Units.dp(10)
                 sourceComponent: stackViewMain
             }
             Loader {
                 id: radioInformationViewLoader
+                Layout.minimumWidth: Units.dp(50)
                 Layout.preferredWidth: Units.dp(400)
                 Layout.margins: Units.dp(10)
                 sourceComponent: radioInformationView
             }
             Loader {
                 id: expertViewLoader
+                Layout.minimumWidth: Units.dp(50)
                 Layout.margins: Units.dp(10)
                 Layout.fillWidth: true
                 sourceComponent: expertView


### PR DESCRIPTION
The mininum and preferred sizes is updated for a more consistent values over different modes.

This is a rework of the changes done in:
https://github.com/AlbrechtL/welle.io/commit/541354ced93f2567d37a2f4e5a74724d8618bc89
https://github.com/AlbrechtL/welle.io/commit/e826d606e25f128f0ddc55e30633934454d32ac7
as these commits leave inconsistent values between different modes.
