### PR TITLE
viterbi_spiral.c removed from the repository.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,6 @@ set(sources
     src/ofdm/phasetable.cpp
     src/ofdm/freq-interleaver.cpp
     src/backend/viterbi.cpp
-    src/backend/viterbi_spiral.c
     src/backend/fic-handler.cpp
     src/backend/msc-handler.cpp
     src/backend/eep-protection.cpp


### PR DESCRIPTION
This pull request amends the CMake build to account for the removal of the viterbi_spiral.c file.