### PR TITLE
 Play a known station from config -> last played or command line

### DIFF
--- a/src/gui/QML/ChannelBrowser.qml
+++ b/src/gui/QML/ChannelBrowser.qml
@@ -11,6 +11,7 @@ Item {
     property alias settingsVisible: item2.visible
     property alias infoPageVisible: infoPageLoader.visible
     property alias enableFullScreenState : enableFullScreen.checked
+    property alias enableLastPlayedStationState : enableLastPlayedStation.checked
     property alias enableExpertModeState : enableExpertMode.checked
     property alias enableAGCState : enableAGC.checked
     property alias manualGainState : manualGain.currentValue
@@ -567,7 +568,6 @@ Item {
             }
         }
 
-
         TouchSwitch {
             id: enableFullScreen
             name: qsTr("Full screen mode")
@@ -575,7 +575,16 @@ Item {
             Layout.fillHeight: true
             objectName: "enableFullScreen"
             checked: false
-        }        
+        }
+
+        TouchSwitch {
+            id: enableLastPlayedStation
+            name: qsTr("Last station")
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            objectName: "enableLastPlayedStation"
+            checked: false
+        }
 
         TouchSwitch {
             id: enable3D

--- a/src/gui/QML/SettingsPage.qml
+++ b/src/gui/QML/SettingsPage.qml
@@ -9,6 +9,7 @@ import "style"
 Item {
     id: settingsPage
     property alias enableFullScreenState : enableFullScreen.checked
+    property alias enableLastPlayedStationState : enableLastPlayedStation.checked
     property alias enableExpertModeState : enableExpertMode.checked
     property alias enableAGCState : enableAGC.checked
     property alias enableHwAGCState : enableHwAGC.checked
@@ -17,6 +18,7 @@ Item {
 
     Settings {
         property alias enableFullScreenState : settingsPage.enableFullScreenState
+        property alias enableLastPlayedStationState : settingsPage.enableLastPlayedStationState
         property alias enableExpertModeState : settingsPage.enableExpertModeState
         property alias manualGainState : settingsPage.manualGainState
         property alias manualGainValue: manualGain.showCurrentValue
@@ -232,6 +234,16 @@ Item {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
                             objectName: "enableFullScreen"
+                            checked: false
+                        }
+
+                        TouchSwitch {
+                            id: enableLastPlayedStation
+                            name: qsTr("Last played")
+                            height: 24
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            objectName: "enableLastPlayedStation"
                             checked: false
                         }
 

--- a/src/gui/QML/main.qml
+++ b/src/gui/QML/main.qml
@@ -290,6 +290,7 @@ ApplicationWindow {
             Component.onCompleted: {
                 settingsVisible = backButton.isSettings
                 enableFullScreenState = settingsPage.enableFullScreenState
+                enableLastPlayedStationState = settingsPage.enableLastPlayedStationState
                 enableExpertModeState = settingsPage.enableExpertModeState
                 enableAGCState = settingsPage.enableAGCState
                 manualGainState = settingsPage.manualGainState
@@ -305,6 +306,11 @@ ApplicationWindow {
             onEnableFullScreenStateChanged: {
                 settingsPage.enableFullScreenState = enableFullScreenState
             }
+
+            onEnableLastPlayedStationStateChanged:  {
+                settingsPage.enableLastPlayedStationState = enableLastPlayedStationState
+            }
+
             onManualGainStateChanged: {
                 settingsPage.manualGainState = manualGainState
             }


### PR DESCRIPTION
For using a Rasperry Pi without Monitor i needed a feature to play stations without a frontend / click.  

- Added "last played" option to settings page. If enabled **welle.io** will try to start last played station on program start (Linux and RPI tested). References #9 (Save last station)
- Added `--station <Station name>` command line option to play a specific station from a previous channel scan. References #37 

It takes some seconds before a channel is playing but basically it is working and has room for improvement. 
 

