### PR TITLE
added PPM

### DIFF
--- a/src/CRadioController.cpp
+++ b/src/CRadioController.cpp
@@ -108,6 +108,7 @@ void CRadioController::ResetTechnicalData(void)
     mIsSignal = false;
     mSNR = 0;
     mFrequencyCorrection = 0;
+    mFrequencyCorrectionPpm = 0.0f;
     mBitRate = 0;
     mAudioSampleRate = 0;
     mIsStereo = true;
@@ -573,6 +574,11 @@ int CRadioController::FrequencyCorrection() const
     return mFrequencyCorrection;
 }
 
+float CRadioController::FrequencyCorrectionPpm() const
+{
+    return mFrequencyCorrectionPpm;
+}
+
 int CRadioController::BitRate() const
 {
     return mBitRate;
@@ -1026,6 +1032,12 @@ void CRadioController::onFrequencyCorrectorChange(int fine, int coarse)
         return;
     mFrequencyCorrection = coarse + fine;
     emit FrequencyCorrectionChanged(mFrequencyCorrection);
+
+    if (CurrentFrequency != 0)
+    {
+        mFrequencyCorrectionPpm = -(1e6 * (float)mFrequencyCorrection) / (float)CurrentFrequency;
+        emit FrequencyCorrectionPpmChanged(mFrequencyCorrectionPpm);
+    }
 }
 
 void CRadioController::onSyncChange(char isSync)

--- a/src/CRadioController.h
+++ b/src/CRadioController.h
@@ -72,7 +72,7 @@ class CRadioController :
     Q_PROPERTY(bool isDAB READ isDAB NOTIFY isDABChanged)
     Q_PROPERTY(int SNR READ SNR NOTIFY SNRChanged)
     Q_PROPERTY(int FrequencyCorrection READ FrequencyCorrection NOTIFY FrequencyCorrectionChanged)
-    Q_PROPERTY(float FrequencyCorrectionPpm READ FrequencyCorrectionPpm NOTIFY FrequencyCorrectionChangedPpm)
+    Q_PROPERTY(float FrequencyCorrectionPpm READ FrequencyCorrectionPpm NOTIFY FrequencyCorrectionPpmChanged)
     Q_PROPERTY(int BitRate READ BitRate NOTIFY BitRateChanged)
     Q_PROPERTY(int AudioSampleRate READ AudioSampleRate NOTIFY AudioSampleRateChanged)
     Q_PROPERTY(int FrameErrors READ FrameErrors NOTIFY FrameErrorsChanged)
@@ -278,7 +278,7 @@ signals:
     void isDABChanged(bool);
     void SNRChanged(int);
     void FrequencyCorrectionChanged(int);
-    void FrequencyCorrectionChangedPpm(float);
+    void FrequencyCorrectionPpmChanged(float);
     void BitRateChanged(int);
     void AudioSampleRateChanged(int);
     void FrameErrorsChanged(int);

--- a/src/CRadioController.h
+++ b/src/CRadioController.h
@@ -72,6 +72,7 @@ class CRadioController :
     Q_PROPERTY(bool isDAB READ isDAB NOTIFY isDABChanged)
     Q_PROPERTY(int SNR READ SNR NOTIFY SNRChanged)
     Q_PROPERTY(int FrequencyCorrection READ FrequencyCorrection NOTIFY FrequencyCorrectionChanged)
+    Q_PROPERTY(float FrequencyCorrectionPpm READ FrequencyCorrectionPpm NOTIFY FrequencyCorrectionChangedPpm)
     Q_PROPERTY(int BitRate READ BitRate NOTIFY BitRateChanged)
     Q_PROPERTY(int AudioSampleRate READ AudioSampleRate NOTIFY AudioSampleRateChanged)
     Q_PROPERTY(int FrameErrors READ FrameErrors NOTIFY FrameErrorsChanged)
@@ -130,6 +131,7 @@ public:
     bool isDAB() const;
     int SNR() const;
     int FrequencyCorrection() const;
+    float FrequencyCorrectionPpm() const;
     int BitRate() const;
     int AudioSampleRate() const;
     int FrameErrors() const;
@@ -207,6 +209,7 @@ private:
     bool mIsDAB;
     int mSNR;
     int mFrequencyCorrection;
+    float mFrequencyCorrectionPpm;
     int mBitRate;
     int mAudioSampleRate;
     int mFrameErrors;
@@ -275,6 +278,7 @@ signals:
     void isDABChanged(bool);
     void SNRChanged(int);
     void FrequencyCorrectionChanged(int);
+    void FrequencyCorrectionChangedPpm(float);
     void BitRateChanged(int);
     void AudioSampleRateChanged(int);
     void FrameErrorsChanged(int);

--- a/src/CRadioController.rep
+++ b/src/CRadioController.rep
@@ -15,6 +15,7 @@ class CRadioController
     PROP(bool isDAB READONLY);
     PROP(int SNR READONLY);
     PROP(int FrequencyCorrection READONLY);
+    PROP(float FrequencyCorrectionPpm READONLY);
     PROP(int BitRate READONLY);
     PROP(int AudioSampleRate READONLY);
     PROP(int FrameErrors READONLY);

--- a/src/gui/QML/ExpertView.qml
+++ b/src/gui/QML/ExpertView.qml
@@ -29,7 +29,7 @@ Item {
         TextExpert {
             id: displayFreqCorr
             name: qsTr("Frequency correction") + ":"
-            text: cppRadioController.FrequencyCorrection + " Hz"
+            text: cppRadioController.FrequencyCorrection + " Hz (" + cppRadioController.FrequencyCorrectionPpm.toFixed(2) + " ppm)"
         }
 
         TextExpert {


### PR DESCRIPTION
following the idea in the article
[Using ... and DAB Signals to Calibrate RTL-SDR Dongles](https://www.rtl-sdr.com/using-qirx-sdr-and-dab-signals-to-calibrate-rtl-sdr-dongles/)
to use DAB to calibrate SDR dongles, i added ppm to welle.io as well to the expert view just behind, where frequency correction is show.

see also [show "ppm" in addition to frequencey correction #238](https://github.com/AlbrechtL/welle.io/issues/238)

PS.: only tested on ubuntu 18.04 LTS + Qt 5.10.1