### PR TITLE
[Next] fix manual gain slider

### DIFF
--- a/src/gui/QML/settingpages/GlobalSettings.qml
+++ b/src/gui/QML/settingpages/GlobalSettings.qml
@@ -241,15 +241,15 @@ Item {
 
                         Slider {
                             id: manualGain
-                            from: 100
-                            to: 0
+                            from: 0
+                            to: 100
                             value: manualGainState
                             stepSize: 1
 
                             Layout.preferredWidth: parent.width
                             onValueChanged: {
                                 if(enableAGC.checked == false)
-                                                cppGUI.inputGainChanged(valueGain)
+                                    cppGUI.inputGainChanged(manualGainState)
                             }
                         }
                     }


### PR DESCRIPTION
The fix with from/to I did in the other file still works when applying it in GlobalSettings.qml.

But there was a new problem and using the slider print ou these error messages:
"qrc:/src/gui/QML/settingpages/GlobalSettings.qml:252: ReferenceError: valueGain is not defined"

I fixed that problem too by using 'manualGainState' instead of 'valueGain'.