### PR TITLE
Remove qt5_use_module from CMakeFile.txt as it is obsoleted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,9 +130,14 @@ target_link_libraries (${executableName}
   ${FAAD_LIBRARIES}
   ${SoapySDR_LIBRARIES}
   Threads::Threads
+  Qt5::Widgets
+  Qt5::Quick
+  Qt5::Multimedia
+  Qt5::Charts
 )
 
-qt5_use_modules(${executableName} Widgets Quick Multimedia Charts)
+#qt5_use_modules(${executableName} Widgets Quick Multimedia Charts)
+
 
 INSTALL (TARGETS ${executableName} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ target_link_libraries (${executableName}
   Qt5::Charts
 )
 
-#qt5_use_modules(${executableName} Widgets Quick Multimedia Charts)
 
 
 INSTALL (TARGETS ${executableName} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
When I try to compile master this happens:
```
$  cmake ..
-- Build type not specified: defaulting to release.
CMake Error at CMakeLists.txt:135 (qt5_use_modules):
  Unknown CMake command "qt5_use_modules".


-- Configuring incomplete, errors occurred!
See also "/home/feanor/Development/Programming/welle.io/build/CMakeFiles/CMakeOutput.log".
See also "/home/feanor/Development/Programming/welle.io/build/CMakeFiles/CMakeError.log".
```
Googling that error results to this: https://github.com/brezerk/q4wine/issues/125 and https://doc.qt.io/qt-5/cmake-manual.html#qt5core-macros that states that `qt5_use_module` is obsolete and we should use `target-link-libraries` instead, so I use the same fix as the other github link and now it compiles 