### PR TITLE
Drop extra semi-colons on some functions

### DIFF
--- a/src/backend/dab-virtual.h
+++ b/src/backend/dab-virtual.h
@@ -29,7 +29,7 @@
 
 class DabVirtual {
     public:
-        virtual ~DabVirtual() {};
+        virtual ~DabVirtual() {}
         virtual int32_t process(int16_t *v, int16_t cnt) = 0;
 };
 #endif

--- a/src/input/CVirtualInput.h
+++ b/src/input/CVirtualInput.h
@@ -38,7 +38,7 @@ enum class CDeviceID {
 
 class CVirtualInput : public InputInterface {
     public:
-        virtual ~CVirtualInput() {};
+        virtual ~CVirtualInput() {}
         virtual CDeviceID getID(void) = 0;
 };
 


### PR DESCRIPTION
The warning from clang is:
``` 
./src/input/CVirtualInput.h(41,36):  warning: extra ';' after member function definition [-Wextra-semi]
        virtual ~CVirtualInput() {};
```
There are more files with this warning. How to add those to this PR?

