### PR TITLE
[macOS] Update homebrew formula

### DIFF
--- a/HomebrewFormula/welle.io.rb
+++ b/HomebrewFormula/welle.io.rb
@@ -9,6 +9,7 @@ class WelleIo < Formula
   depends_on "qt"
   depends_on "fftw"
   depends_on "faad2"
+  depends_on "librtlsdr"
   depends_on "soapysdr"
   depends_on "soapyuhd"
   depends_on "libusb"

--- a/HomebrewFormula/welle.io.rb
+++ b/HomebrewFormula/welle.io.rb
@@ -1,8 +1,8 @@
 class WelleIo < Formula
   desc "DAB/DAB+ Software Radio"
   homepage "https://www.welle.io"
-  url "https://github.com/AlbrechtL/welle.io/archive/V1.0.tar.gz"
-  sha256 "669ae5d471f723c32622cbf6ee37b66c3aefd8e02d6334b55d1fb60b3c22a883"
+  url  "https://github.com/AlbrechtL/welle.io/archive/v2.0-beta1.tar.gz"
+  sha256 "b81df164fcf74ec58629afa1e00911d63a1f8abdc875dd7dda3a04d975db83d4"
   head "https://github.com/AlbrechtL/welle.io.git"
 
   depends_on "cmake" => :build

--- a/HomebrewFormula/welle.io.rb
+++ b/HomebrewFormula/welle.io.rb
@@ -15,7 +15,7 @@ class WelleIo < Formula
   depends_on "libusb"
 
   def install
-    system "cmake", ".", "-DSOAPYSDR=TRUE", "-DBUILD_WELLE_CLI=OFF", *std_cmake_args
+    system "cmake", ".", "-DRTLSDR=TRUE", "-DSOAPYSDR=TRUE", "-DBUILD_WELLE_CLI=OFF", *std_cmake_args
     system "make", "install"
   end
 

--- a/HomebrewFormula/welle.io.rb
+++ b/HomebrewFormula/welle.io.rb
@@ -9,11 +9,12 @@ class WelleIo < Formula
   depends_on "qt"
   depends_on "fftw"
   depends_on "faad2"
-  depends_on "librtlsdr"
+  depends_on "soapysdr"
+  depends_on "soapyuhd"
   depends_on "libusb"
 
   def install
-    system "cmake", ".", "-DRTLSDR=TRUE", "-DBUILD_WELLE_CLI=OFF", *std_cmake_args
+    system "cmake", ".", "-DSOAPYSDR=TRUE", "-DBUILD_WELLE_CLI=OFF", *std_cmake_args
     system "make", "install"
   end
 


### PR DESCRIPTION
modified homebrew formula to support building with sopaysdr support by adding the depends as well as the -DSOAPYSDR=TRUE cmake flags