### PR TITLE
Fix dependencies in homebrew formula

### DIFF
--- a/HomebrewFormula/welle.io.rb
+++ b/HomebrewFormula/welle.io.rb
@@ -9,9 +9,10 @@ class WelleIo < Formula
   depends_on "qt"
   depends_on "fftw"
   depends_on "faad2"
+  depends_on "mpg123"
   depends_on "librtlsdr"
-  depends_on "soapysdr"
-  depends_on "soapyuhd"
+  depends_on "pothosware/homebrew-pothos/soapysdr"
+  depends_on "pothosware/homebrew-pothos/soapyuhd"
   depends_on "libusb"
 
   def install


### PR DESCRIPTION
The current homebrew formula fails to build due to the following reasons:

- The dependency on mpg123 has not been specified, so the build fails if it has not been installed separately.
- The recently added dependency on SoapySDR (see #346) is not part of the homebrew repository, and the dependency does not specify the repository it can be installed from. Therefore homebrew refuses to install welle.io as it can't find the formula for SoapySDR, requiring its tap to be manually added.

This pull request fixes the dependencies in the formula so welle.io can be installed by homebrew without any extra steps being carried out first.