### PR TITLE
Enable translation for missing elements in settings

### DIFF
--- a/src/welle-gui/QML/settingpages/ExpertSettings.qml
+++ b/src/welle-gui/QML/settingpages/ExpertSettings.qml
@@ -61,7 +61,7 @@ Item {
 
                 WComboBox {
                     id: freqSyncMethodBox
-                    model: [ "GetMiddle", "CorrelatePRS", "PatternOfZeros" ];
+                    model: [ qsTr("GetMiddle"), qsTr("CorrelatePRS"), qsTr("PatternOfZeros") ];
                     currentIndex: 1
                     onCurrentIndexChanged: {
                         radioController.setFreqSyncMethod(currentIndex)
@@ -92,7 +92,7 @@ Item {
                 Layout.fillWidth: true
                 WComboBox {
                     id: fftPlacementBox
-                    model: [ "Strongest Peak", "Earliest Peak With Binning", "Threshold Before Peak" ];
+                    model: [ qsTr("Strongest Peak"), qsTr("Earliest Peak With Binning"), qsTr("Threshold Before Peak") ];
                     currentIndex: 1
                     onCurrentIndexChanged: {
                         radioController.selectFFTWindowPlacement(currentIndex)

--- a/src/welle-gui/QML/settingpages/GlobalSettings.qml
+++ b/src/welle-gui/QML/settingpages/GlobalSettings.qml
@@ -156,7 +156,7 @@ Item {
                 id: deviceBox
                 enabled: !enableAutoSdr.checked
                 Layout.fillWidth: true
-                model: [ "None", "Airspy", "rtl-sdr", "SoapySDR", "rtl-tcp", "RAW file"];
+                model: [ qsTr("None"), qsTr("Airspy"), qsTr("rtl-sdr"), qsTr("SoapySDR"), qsTr("rtl-tcp"), qsTr("RAW file")];
                 onCurrentIndexChanged: {
                     // Load appropriate settings
                     switch(currentIndex) {


### PR DESCRIPTION
- Enable translation for the deviceBox (in global settings)
- Enable translation for freqSyncMethodBox & fftPlacementBox  (in expert settings)