### PR TITLE
wordwrap station name

### DIFF
--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -82,6 +82,10 @@ ViewBaseFrame {
             Layout.alignment: Qt.AlignHCenter
 
             TextRadioStation {
+                Layout.margins: Units.dp(10)
+                Layout.maximumWidth: parent.parent.parent.width
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
                 text: radioController.title.trim()
 
                 // Use a button to display a icon

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -19,29 +19,93 @@ ViewBaseFrame {
         text: radioController.ensemble.trim()
     }
 
-    // Use a button to display a icon
-    Button {
-        anchors.top: parent.top
+    // Use 2 buttons to switch between speaker & speaker_mute icon (instead of toggle button)
+    /*Button {
+        id: speakerIcon
+        anchors.verticalCenter: signalStrength.verticalCenter
         anchors.right: parent.right
-        anchors.topMargin: Units.dp(-20) // ToDo Hack!
-        anchors.rightMargin: Units.dp(-10) // ToDo Hack!
-
-        background: Rectangle { opacity: 0} // Hack to disable the pressed color
-        checkable: true
+        width: Units.dp(50)
+        height: Units.dp(50)
+        visible: true
         flat: true
 
-        icon.name: checked ? "speaker_mute" : "speaker"
+        icon.name: "speaker"
         icon.width: Units.dp(30)
         icon.height: Units.dp(30)
-        icon.color: checked ? "red" : "transparent"
+        icon.color: "transparent"
 
         implicitWidth: contentItem.implicitWidth + Units.dp(30)
         implicitHeight: implicitWidth
 
-        onCheckedChanged: checked ? radioController.setVolume(0) : radioController.setVolume(100)
+        onClicked: {radioController.setVolume(0); speakerIconMutedRed.visible = true; speakerIcon.visible = false}
+    }
+    
+    Button {
+        id: speakerIconMuted
+        anchors.verticalCenter: signalStrength.verticalCenter
+        anchors.right: parent.right
+        width: Units.dp(50)
+        height: Units.dp(50)
+        visible: false
+        flat: true
+
+        icon.name: "speaker_mute"
+        icon.width: Units.dp(30)
+        icon.height: Units.dp(30)
+        icon.color: "red"
+
+        implicitWidth: contentItem.implicitWidth + Units.dp(30)
+        implicitHeight: implicitWidth
+
+        onClicked: {radioController.setVolume(100); speakerIconMuted.visible = false; speakerIcon.visible = true}
+    }
+    */
+
+    // Use 2 Images to switch between speaker & speaker_mute icon (instead of toggle button). 
+    // Permits use of color with org.kde.desktop style
+    Image {
+        id: speakerIcon
+        anchors.verticalCenter: signalStrength.verticalCenter
+        anchors.right: parent.right
+        width: Units.dp(30)
+        height: Units.dp(30)
+        visible: true
+        //flat: true
+        source: "qrc:/icon/welle_io_icons/20x20@2/speaker.png"
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {radioController.setVolume(0); speakerIconMutedRed.visible = true; speakerIcon.visible = false}
+        }
+    }
+
+    Image {
+        id: speakerIconMuted
+        anchors.verticalCenter: signalStrength.verticalCenter
+        anchors.right: parent.right
+        width: Units.dp(30)
+        height: Units.dp(30)
+        //Layout.preferredWidth: Units.dp(40)
+        //Layout.preferredHeight: Units.dp(40)
+        visible: false
+
+        source: "qrc:/icon/welle_io_icons/20x20@2/speaker_mute.png"
+    }
+
+    ColorOverlay {
+        id: speakerIconMutedRed
+        visible: false
+        anchors.fill: speakerIconMuted
+        source: speakerIconMuted
+        color: "red"
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {radioController.setVolume(100); speakerIconMutedRed.visible = false; speakerIcon.visible = true}
+        }
     }
 
     RowLayout{
+        id: signalStrength
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.leftMargin: Units.dp(5)
@@ -86,7 +150,7 @@ ViewBaseFrame {
                 id:textRadioStation
                 Layout.margins: Units.dp(10)
                 Layout.maximumWidth: parent.parent.parent.width
-                wrapMode: Text.WordWrap
+                wrapMode: Text.Wrap
                 horizontalAlignment: Text.AlignHCenter
                 text: radioController.title.trim()
 
@@ -224,9 +288,11 @@ ViewBaseFrame {
         width: parent.width
 
         TextRadioInfo {
+            id: stationType
             visible: stationInfo.visible
             Layout.alignment: Qt.AlignLeft
             Layout.leftMargin: Units.dp(5)
+            verticalAlignment: Text.AlignBottom
             text: radioController.stationType
         }
 
@@ -234,6 +300,10 @@ ViewBaseFrame {
             visible: stationInfo.visible
             Layout.alignment: Qt.AlignRight
             Layout.rightMargin: Units.dp(5)
+            verticalAlignment: Text.AlignBottom
+            Layout.maximumWidth: parent.parent.width - stationType.width
+            fontSizeMode: Text.Fit
+            minimumPixelSize: 8;
             text: (radioController.isDAB ? "DAB" : "DAB+")
                 + " " + radioController.audioMode
         }

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -82,6 +82,7 @@ ViewBaseFrame {
             Layout.alignment: Qt.AlignHCenter
 
             TextRadioStation {
+                id:textRadioStation
                 Layout.margins: Units.dp(10)
                 Layout.maximumWidth: parent.parent.parent.width
                 wrapMode: Text.WordWrap
@@ -92,8 +93,40 @@ ViewBaseFrame {
                 Button  {
                     property bool isSignal: false
                     id: antennaSymbol
-                    x: parent.width + Units.dp(5)
-                    y: (parent.height / 2) - (height / 2)
+                    property bool isTextTooLongForAntenna: {return (parent.width + implicitWidth + Units.dp(30) > parent.parent.parent.parent.width)}
+
+                    Connections {
+                        target: frame
+                        onWidthChanged: { reanchorAntenna() }
+                    }
+                    
+                    Connections {
+                        target: textRadioStation
+                        onTextChanged: { reanchorAntenna() }
+                    }
+                    
+                    states: [
+                        State {
+                          name: "alignRight"
+                          AnchorChanges {
+                            target: antennaSymbol
+                            anchors.left: textRadioStation.right
+                            anchors.verticalCenter: textRadioStation.verticalCenter
+                            anchors.top: undefined
+                            anchors.horizontalCenter: undefined
+                          }
+                        },
+                        State {
+                          name: "alignBottom"
+                          AnchorChanges {
+                            target: antennaSymbol
+                            anchors.left: undefined
+                            anchors.verticalCenter: undefined
+                            anchors.top: textRadioStation.bottom
+                            anchors.horizontalCenter: textRadioStation.horizontalCenter
+                          }
+                        }
+                    ]
 
                     visible: opacity == 0 ? false : true
                     opacity: 100
@@ -183,4 +216,12 @@ ViewBaseFrame {
             effect.stop()
         }
     }
+
+    function reanchorAntenna() {
+        if (!antennaSymbol.isTextTooLongForAntenna)
+            antennaSymbol.state = "alignRight"
+        else
+            antennaSymbol.state = "alignBottom"
+    }
+    
 }

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -193,7 +193,7 @@ ViewBaseFrame {
                             else
                                 __setIsSignal(false)
                         }
-                        
+
                         onIsSyncChanged: {
                             if(radioController.isSync)
                                 __setIsSignal(true)
@@ -263,5 +263,4 @@ ViewBaseFrame {
         else
             antennaSymbol.state = "alignBottom"
     }
-    
 }

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -19,48 +19,6 @@ ViewBaseFrame {
         text: radioController.ensemble.trim()
     }
 
-    // Use 2 buttons to switch between speaker & speaker_mute icon (instead of toggle button)
-    /*Button {
-        id: speakerIcon
-        anchors.verticalCenter: signalStrength.verticalCenter
-        anchors.right: parent.right
-        width: Units.dp(50)
-        height: Units.dp(50)
-        visible: true
-        flat: true
-
-        icon.name: "speaker"
-        icon.width: Units.dp(30)
-        icon.height: Units.dp(30)
-        icon.color: "transparent"
-
-        implicitWidth: contentItem.implicitWidth + Units.dp(30)
-        implicitHeight: implicitWidth
-
-        onClicked: {radioController.setVolume(0); speakerIconMutedRed.visible = true; speakerIcon.visible = false}
-    }
-    
-    Button {
-        id: speakerIconMuted
-        anchors.verticalCenter: signalStrength.verticalCenter
-        anchors.right: parent.right
-        width: Units.dp(50)
-        height: Units.dp(50)
-        visible: false
-        flat: true
-
-        icon.name: "speaker_mute"
-        icon.width: Units.dp(30)
-        icon.height: Units.dp(30)
-        icon.color: "red"
-
-        implicitWidth: contentItem.implicitWidth + Units.dp(30)
-        implicitHeight: implicitWidth
-
-        onClicked: {radioController.setVolume(100); speakerIconMuted.visible = false; speakerIcon.visible = true}
-    }
-    */
-
     // Use 2 Images to switch between speaker & speaker_mute icon (instead of toggle button). 
     // Permits use of color with org.kde.desktop style
     Image {
@@ -70,7 +28,6 @@ ViewBaseFrame {
         width: Units.dp(30)
         height: Units.dp(30)
         visible: true
-        //flat: true
         source: "qrc:/icon/welle_io_icons/20x20@2/speaker.png"
 
         MouseArea {
@@ -85,8 +42,6 @@ ViewBaseFrame {
         anchors.right: parent.right
         width: Units.dp(30)
         height: Units.dp(30)
-        //Layout.preferredWidth: Units.dp(40)
-        //Layout.preferredHeight: Units.dp(40)
         visible: false
 
         source: "qrc:/icon/welle_io_icons/20x20@2/speaker_mute.png"

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -168,13 +168,10 @@ ViewBaseFrame {
                     Connections {
                         target: antennaSymbol
                         onIsSignalChanged: { 
-                            console.log("onIsSignalChanged")
                             if (antennaSymbol.isSignal) {
-                                console.log("isSignal")
                                 antennaIconNoSignalRed.visible = false; 
                                 antennaIcon.visible = true;
                             } else {
-                                console.log("NoisSignal")
                                 antennaIconNoSignalRed.visible = true; 
                                 antennaIcon.visible = false;
                             }
@@ -187,25 +184,23 @@ ViewBaseFrame {
                         duration: 6000;
                         running: false
                     }
-                    
-                    
+
                     Connections {
                         target: radioController
                         onIsFICCRCChanged: {
                             if(radioController.isFICCRC)
                                 __setIsSignal(true)
-                                else
-                                    __setIsSignal(false)
+                            else
+                                __setIsSignal(false)
                         }
                         
                         onIsSyncChanged: {
                             if(radioController.isSync)
                                 __setIsSignal(true)
-                                else
-                                    __setIsSignal(false)
+                            else
+                                __setIsSignal(false)
                         }
                     }
-                    
                 }
             }
         }


### PR DESCRIPTION
Station name is sometimes too long to fit in the service overview display panel.
This will word wrap the label

BTW, it also wraps the "playing the last station" text at startup