### PR TITLE
Enable translation of strings from the input directory

### DIFF
--- a/src/backend/radio-controller.h
+++ b/src/backend/radio-controller.h
@@ -112,7 +112,7 @@ class RadioControllerInterface {
         virtual void onTIIMeasurement(tii_measurement_t&& m) = 0;
 
         /* When a information or warning message should be printed */
-        virtual void onMessage(message_level_t level, const std::string& text) = 0;
+        virtual void onMessage(message_level_t level, const std::string& text, const std::string& text2 = std::string()) = 0;
 
         /* The receiver has shutdown */
         virtual void onShutdown(void) { };

--- a/src/input/airspy_sdr.cpp
+++ b/src/input/airspy_sdr.cpp
@@ -35,6 +35,13 @@
 #include <iostream>
 #include "airspy_sdr.h"
 
+// For Qt translation if Qt is exisiting
+#ifdef QT_CORE_LIB
+    #include <QtGlobal>
+#else
+    #define QT_TRANSLATE_NOOP(x,y) (y)
+#endif
+
 static const int EXTIO_NS = 8192;
 static const int EXTIO_BASE_TYPE_SIZE = sizeof(float);
 
@@ -142,7 +149,7 @@ bool CAirspy::is_ok()
     airspy_error status =  (airspy_error) airspy_is_streaming(device);
     if(status != AIRSPY_TRUE && running == true) {
         std::clog << "Airspy: airspy is not working. Maybe it is unplugged. Code: " << status <<  "running" << running << std::endl;
-        radioController.onMessage(message_level_t::Error, "airspy is unplugged.");
+        radioController.onMessage(message_level_t::Error, QT_TRANSLATE_NOOP("CRadioController", "airspy is unplugged."));
 
         stop();
     }

--- a/src/input/input_factory.cpp
+++ b/src/input/input_factory.cpp
@@ -28,6 +28,13 @@
 
 #include <iostream>
 
+// For Qt translation if Qt is exisiting
+#ifdef QT_CORE_LIB
+    #include <QtGlobal>
+#else
+    #define QT_TRANSLATE_NOOP(x,y) (y)
+#endif
+
 #include "input_factory.h"
 #include "null_device.h"
 #include "rtl_tcp.h"
@@ -65,9 +72,9 @@ CVirtualInput *CInputFactory::GetDevice(RadioControllerInterface& radioControlle
         std::string text;
 
         if (device == "auto")
-            text = "No valid device found use Null device instead.";
+            text = QT_TRANSLATE_NOOP("CRadioController", "No valid device found use Null device instead.");
         else
-            text = "Error while opening device";
+            text = QT_TRANSLATE_NOOP("CRadioController", "Error while opening device");
 
         radioController.onMessage(message_level_t::Error, text);
         InputDevice = new CNullDevice();
@@ -107,7 +114,7 @@ CVirtualInput *CInputFactory::GetDevice(RadioControllerInterface &radioControlle
 
     // Fallback if no device is found or an error occured
     if (InputDevice == nullptr) {
-        std::string text = "Error while opening device";
+        std::string text = QT_TRANSLATE_NOOP("CRadioController", "Error while opening device");
         radioController.onMessage(message_level_t::Error, text);
         InputDevice = new CNullDevice();
     }

--- a/src/input/raw_file.cpp
+++ b/src/input/raw_file.cpp
@@ -41,6 +41,13 @@
 
 #include "raw_file.h"
 
+// For Qt translation if Qt is exisiting
+#ifdef QT_CORE_LIB
+    #include <QtGlobal>
+#else
+    #define QT_TRANSLATE_NOOP(x,y) (y)
+#endif
+
 static inline int64_t getMyTime(void)
 {
     struct timeval tv;
@@ -167,7 +174,7 @@ void CRAWFile::setFileName(const std::string& fileName,
     if (filePointer == nullptr) {
         std::clog << "RAWFile: Cannot open file: " << fileName << std::endl;
         radioController.onMessage(message_level_t::Error,
-                "Cannot open file " + fileName);
+                QT_TRANSLATE_NOOP("CRadioController", "Cannot open file "), fileName);
         return;
     }
 
@@ -187,7 +194,7 @@ void CRAWFile::setFileHandle(int handle, const std::string& fileFormat)
     if (filePointer == nullptr) {
         std::clog << "RAWFile: Cannot open file: " << fileName << std::endl;
         radioController.onMessage(message_level_t::Error,
-                "Cannot open file " + fileName);
+                QT_TRANSLATE_NOOP("CRadioController", "Cannot open file "), fileName);
         return;
     }
 
@@ -300,10 +307,10 @@ int32_t CRAWFile::readBuffer(uint8_t* data, int32_t length)
             fseek(filePointer, 0, SEEK_SET);
             std::clog << "RAWFile:"  << "End of file, restarting" << std::endl;
             radioController.onMessage(message_level_t::Information,
-                    "End of file, restarting");
+                    QT_TRANSLATE_NOOP("CRadioController", "End of file, restarting"));
         }
         else {
-            radioController.onMessage(message_level_t::Information, "End of file");
+            radioController.onMessage(message_level_t::Information, QT_TRANSLATE_NOOP("CRadioController", "End of file"));
             endReached = true;
             return 0;
         }
@@ -391,6 +398,6 @@ void CRAWFile::setFileFormat(const std::string &fileFormat)
         this->fileFormat = CRAWFileFormat::Unknown;
         std::clog << "RAWFile: unknown file format" << std::endl;
         radioController.onMessage(message_level_t::Error,
-                "Unknown RAW file format");
+                QT_TRANSLATE_NOOP("CRadioController", "Unknown RAW file format"));
     }
 }

--- a/src/input/rtl_sdr.cpp
+++ b/src/input/rtl_sdr.cpp
@@ -35,6 +35,13 @@
 
 #include "rtl_sdr.h"
 
+// For Qt translation if Qt is exisiting
+#ifdef QT_CORE_LIB
+    #include <QtGlobal>
+#else
+    #define QT_TRANSLATE_NOOP(x,y) (y)
+#endif
+
 #define READLEN_DEFAULT 8192
 
 // Fallback if function is not defined in shared lib
@@ -287,7 +294,7 @@ void CRTL_SDR::AGCTimer(void)
         }
         else { // AGC is off
             if (minAmplitude == 0 || maxAmplitude == 255) {
-                std::string Text = "ADC overload. Maybe you are using a to high gain.";
+                std::string Text = QT_TRANSLATE_NOOP("CRadioController", "ADC overload. Maybe you are using a too high gain.");
                 std::clog << "RTL_SDR:" << Text << std::endl;
                 radioController.onMessage(message_level_t::Information, Text);
             }
@@ -383,7 +390,7 @@ void CRTL_SDR::rtlsdr_read_async_wrapper()
                       (void*)this, 0, READLEN_DEFAULT);
 
     if(rtlsdrRunning)
-        radioController.onMessage(message_level_t::Error, "RTL-SDR is unplugged.");
+        radioController.onMessage(message_level_t::Error, QT_TRANSLATE_NOOP("CRadioController", "RTL-SDR is unplugged."));
 
     rtlsdrUnplugged = true;
     rtlsdrRunning = false;

--- a/src/input/rtl_tcp.cpp
+++ b/src/input/rtl_tcp.cpp
@@ -33,6 +33,13 @@
 #include <iostream>
 #include "rtl_tcp.h"
 
+// For Qt translation if Qt is exisiting
+#ifdef QT_CORE_LIB
+    #include <QtGlobal>
+#else
+    #define QT_TRANSLATE_NOOP(x,y) (y)
+#endif
+
 // commands are packed in 5 bytes, one "command byte"
 // and an integer parameter
 struct command
@@ -262,7 +269,7 @@ void CRTL_TCP_Client::handleDisconnect()
     connected = false;
     firstData = true;
     radioController.onMessage(message_level_t::Error,
-            "RTL-TCP connection closed.");
+            QT_TRANSLATE_NOOP("CRadioController", "RTL-TCP connection closed."));
     sock.close();
 }
 
@@ -403,7 +410,7 @@ void CRTL_TCP_Client::receiveAndReconnect()
                 lock.unlock();
 
                 radioController.onMessage(message_level_t::Error,
-                        "Connection failed to server " +
+                        QT_TRANSLATE_NOOP("CRadioController", "Connection failed to server "),
                         serverAddress + ":" + std::to_string(serverPort));
             }
         }
@@ -452,8 +459,8 @@ void CRTL_TCP_Client::agcTimer(void)
         }
         else { // AGC is off or unknown tuner
             if (minAmplitude == 0 || maxAmplitude == 255) {
-                std::string text = "ADC overload."
-                    " Maybe you are using a to high gain.";
+                std::string text = QT_TRANSLATE_NOOP("CRadioController", "ADC overload."
+                    " Maybe you are using a too high gain.");
                 std::clog << "RTL_TCP_CLIENT:" << text << std::endl;
                 radioController.onMessage(message_level_t::Information, text);
             }

--- a/src/welle-cli/tests.cpp
+++ b/src/welle-cli/tests.cpp
@@ -170,14 +170,20 @@ class TestRadioInterface : public RadioControllerInterface {
 
         virtual void onNewNullSymbol(std::vector<DSPCOMPLEX>&& data) override { (void)data; }
         virtual void onConstellationPoints(std::vector<DSPCOMPLEX>&& data) override { (void)data; }
-        virtual void onMessage(message_level_t level, const std::string& text) override
+        virtual void onMessage(message_level_t level, const std::string& text, const std::string& text2 = std::string()) override
         {
+            std::string fullText;
+            if (text2.empty())
+                fullText = text;
+            else
+                fullText = text + text2;
+
             switch (level) {
                 case message_level_t::Information:
-                    cerr << "Info: " << text << endl;
+                    cerr << "Info: " << fullText << endl;
                     break;
                 case message_level_t::Error:
-                    cerr << "Error: " << text << endl;
+                    cerr << "Error: " << fullText << endl;
                     break;
             }
         }

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -1434,10 +1434,16 @@ void WebRadioInterface::onConstellationPoints(std::vector<DSPCOMPLEX>&& data)
     last_constellation = move(data);
 }
 
-void WebRadioInterface::onMessage(message_level_t level, const std::string& text)
+void WebRadioInterface::onMessage(message_level_t level, const std::string& text, const std::string& text2)
 {
+    std::string fullText;
+    if (text2.empty())
+        fullText = text;
+    else
+        fullText = text + text2;
+    
     lock_guard<mutex> lock(data_mut);
-    pending_messages.emplace_back(level, text);
+    pending_messages.emplace_back(level, fullText);
 }
 
 void WebRadioInterface::onTIIMeasurement(tii_measurement_t&& m)

--- a/src/welle-cli/webradiointerface.h
+++ b/src/welle-cli/webradiointerface.h
@@ -82,7 +82,7 @@ class WebRadioInterface : public RadioControllerInterface {
         virtual void onNewImpulseResponse(std::vector<float>&& data) override;
         virtual void onNewNullSymbol(std::vector<DSPCOMPLEX>&& data) override;
         virtual void onConstellationPoints(std::vector<DSPCOMPLEX>&& data) override;
-        virtual void onMessage(message_level_t level, const std::string& text) override;
+        virtual void onMessage(message_level_t level, const std::string& text, const std::string& text2 = std::string()) override;
         virtual void onTIIMeasurement(tii_measurement_t&& m) override;
         virtual void onShutdown() override;
 

--- a/src/welle-cli/welle-cli.cpp
+++ b/src/welle-cli/welle-cli.cpp
@@ -230,14 +230,20 @@ class RadioInterface : public RadioControllerInterface {
         virtual void onNewImpulseResponse(std::vector<float>&& data) override { (void)data; }
         virtual void onNewNullSymbol(std::vector<DSPCOMPLEX>&& data) override { (void)data; }
         virtual void onConstellationPoints(std::vector<DSPCOMPLEX>&& data) override { (void)data; }
-        virtual void onMessage(message_level_t level, const std::string& text) override
+        virtual void onMessage(message_level_t level, const std::string& text, const std::string& text2 = std::string()) override
         {
+            std::string fullText;
+            if (text2.empty())
+                fullText = text;
+            else
+                fullText = text + text2;
+
             switch (level) {
                 case message_level_t::Information:
-                    cerr << "Info: " << text << endl;
+                    cerr << "Info: " << fullText << endl;
                     break;
                 case message_level_t::Error:
-                    cerr << "Error: " << text << endl;
+                    cerr << "Error: " << fullText << endl;
                     break;
             }
         }

--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -875,14 +875,20 @@ void CRadioController::onTIIMeasurement(tii_measurement_t&& m)
         " with error " << m.error;
 }
 
-void CRadioController::onMessage(message_level_t level, const std::string& text)
+void CRadioController::onMessage(message_level_t level, const std::string& text, const std::string& text2)
 {
+    QString fullText;
+    if (text2.empty())
+      fullText = tr(text.c_str());
+    else
+      fullText = tr(text.c_str()) + QString::fromStdString(text2);
+    
     switch (level) {
         case message_level_t::Information:
-            emit showInfoMessage(tr(text.c_str()));
+            emit showInfoMessage(fullText);
             break;
         case message_level_t::Error:
-            emit showErrorMessage(tr(text.c_str()));
+            emit showErrorMessage(fullText);
             break;
     }
 }

--- a/src/welle-gui/radio_controller.h
+++ b/src/welle-gui/radio_controller.h
@@ -145,7 +145,7 @@ public:
     virtual void onConstellationPoints(std::vector<DSPCOMPLEX>&& data) override;
     virtual void onNewNullSymbol(std::vector<DSPCOMPLEX>&& data) override;
     virtual void onTIIMeasurement(tii_measurement_t&& m) override;
-    virtual void onMessage(message_level_t level, const std::string& text) override;
+    virtual void onMessage(message_level_t level, const std::string& text, const std::string& text2 = std::string()) override;
 
 private:
     void initialise(void);


### PR DESCRIPTION
* Some of the strings in the files of the input directory are not translated and not detected by qtlinguist for translation. This commit should allow the translation for these files.
* Add support for concatenated strings passed to "onMessage" by splitting them and adding an optional argument to the "onMessage" function