### PR TITLE
Fit audiomode to the size of the "service overview" view

### DIFF
--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -147,9 +147,11 @@ ViewBaseFrame {
         width: parent.width
 
         TextRadioInfo {
+            id: stationType
             visible: stationInfo.visible
             Layout.alignment: Qt.AlignLeft
             Layout.leftMargin: Units.dp(5)
+            verticalAlignment: Text.AlignBottom
             text: radioController.stationType
         }
 
@@ -157,6 +159,10 @@ ViewBaseFrame {
             visible: stationInfo.visible
             Layout.alignment: Qt.AlignRight
             Layout.rightMargin: Units.dp(5)
+            verticalAlignment: Text.AlignBottom
+            Layout.maximumWidth: parent.parent.width - stationType.width
+            fontSizeMode: Text.Fit
+            minimumPixelSize: 8;
             text: (radioController.isDAB ? "DAB" : "DAB+")
                 + " " + radioController.audioMode
         }


### PR DESCRIPTION
Sometimes, at the bottom of the "service overview" view,  the PTY and the Audio mode are too long to be well displayed.
This will reduce the size of the Audiomode when length is too long to fit into the "service overview" view