### PR TITLE
Fit labels of "service details" to view size

### DIFF
--- a/src/welle-gui/QML/expertviews/ServiceDetails.qml
+++ b/src/welle-gui/QML/expertviews/ServiceDetails.qml
@@ -24,6 +24,7 @@ ViewBaseFrame {
         }
 
         RowLayout {
+            property bool isServiceDetailsRawLayout: true
             Rectangle{
                 height: Units.dp(16)
                 width: Units.dp(16)
@@ -38,6 +39,7 @@ ViewBaseFrame {
         }
 
         RowLayout {
+            property bool isServiceDetailsRawLayout: true
             Rectangle{
                 height: Units.dp(16)
                 width: Units.dp(16)
@@ -51,6 +53,7 @@ ViewBaseFrame {
         }
 
         RowLayout {
+            property bool isServiceDetailsRawLayout: true
             Rectangle{
                 height: Units.dp(16)
                 width: Units.dp(16)

--- a/src/welle-gui/QML/texts/TextExpert.qml
+++ b/src/welle-gui/QML/texts/TextExpert.qml
@@ -26,6 +26,12 @@ Item{
             font.pixelSize: TextStyle.textStandartSize
             font.family: TextStyle.textFont
             color: TextStyle.textColor
+            verticalAlignment: Text.AlignVCenter
+            Layout.maximumWidth: (parent.parent.parent.isServiceDetailsRawLayout == true) ? 
+                parent.parent.parent.parent.parent.width - nameView.width - 16 :
+                parent.parent.parent.width - nameView.width
+            fontSizeMode: Text.Fit
+            minimumPixelSize: 8;
         }
     }
 }


### PR DESCRIPTION
For me the 
- label of the device
- date&time
are too long and don't completely fit in the "Service details" view.

This will reduce the size of the values so that they can fit in it