### PR TITLE
restoreWindow action fix for linux

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -560,8 +560,14 @@ ApplicationWindow {
         onMinimizeWindow: hide()
         onMaximizeWindow: showMaximized()
         onRestoreWindow: {
+            // On Linux (KDE?): Hide before we restore 
+            // otherwise the window will occasionaly not be brought to the front
+            if (Qt.platform.os === "linux" && !active) // Linux Workaround to display the window
+                hide()
             showNormal()
             raise() // Stay in foreground
+            if (Qt.platform.os === "linux" && !active) // Linux Workaround to display the window
+                requestActivate()
         }
     }
 

--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -875,14 +875,20 @@ void CRadioController::onTIIMeasurement(tii_measurement_t&& m)
         " with error " << m.error;
 }
 
-void CRadioController::onMessage(message_level_t level, const std::string& text)
+void CRadioController::onMessage(message_level_t level, const std::string& text, const std::string& text2)
 {
+    QString fullText;
+    if (text2.empty())
+      fullText = tr(text.c_str());
+    else
+      fullText = tr(text.c_str()) + QString::fromStdString(text2);
+    
     switch (level) {
         case message_level_t::Information:
-            emit showInfoMessage(tr(text.c_str()));
+            emit showInfoMessage(fullText);
             break;
         case message_level_t::Error:
-            emit showErrorMessage(tr(text.c_str()));
+            emit showErrorMessage(fullText);
             break;
     }
 }


### PR DESCRIPTION
On linux, restore Window event doesn't work well. Sometimes the window is brought to the front, some times not. Especially when the window is not minimized.
This will make it work by ensuring the window is hidden first and then request an activation of it