### PR TITLE
restoreWindow action fix for linux

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -560,8 +560,14 @@ ApplicationWindow {
         onMinimizeWindow: hide()
         onMaximizeWindow: showMaximized()
         onRestoreWindow: {
+            // On Linux (KDE?): Hide before we restore 
+            // otherwise the window will occasionaly not be brought to the front
+            if (Qt.platform.os === "linux" && !active) // Linux Workaround to display the window
+                hide()
             showNormal()
             raise() // Stay in foreground
+            if (Qt.platform.os === "linux" && !active) // Linux Workaround to display the window
+                requestActivate()
         }
     }
 


### PR DESCRIPTION
On linux, restore Window event doesn't work well. Sometimes the window is brought to the front, some times not. Especially when the window is not minimized.
This will make it work by ensuring the window is hidden first and then request an activation of it