### PR TITLE
Add combobox to select QtQuickStyle from the GUI

### DIFF
--- a/src/welle-gui/QML/components/WComboBoxList.qml
+++ b/src/welle-gui/QML/components/WComboBoxList.qml
@@ -1,0 +1,22 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.3
+
+import "../texts"
+
+ComboBox {
+    id: comboBox
+
+    font.pixelSize: TextStyle.textStandartSize
+    font.family: TextStyle.textFont
+
+    delegate: ItemDelegate {
+        width: comboBox.width
+        contentItem: TextStandart {
+            text: label;
+            elide: Text.ElideRight
+            verticalAlignment: Text.AlignVCenter
+        }
+        highlighted: comboBox.highlightedIndex === index
+    }
+}

--- a/src/welle-gui/QML/settingpages/GlobalSettings.qml
+++ b/src/welle-gui/QML/settingpages/GlobalSettings.qml
@@ -95,6 +95,23 @@ Item {
                     Layout.fillWidth: true
                 }
             }
+            RowLayout {
+                Layout.fillWidth: true
+                WComboBoxList {
+                    id: styleBox
+                    implicitWidth: 250
+                    currentIndex: guiHelper.getIndexOfQQStyle(guiHelper.getQQStyle)
+                    textRole: "label"
+                    model: guiHelper.qQStyleComboModel
+                    onActivated: {
+                        guiHelper.saveQQStyle(currentIndex)
+                    }
+                }
+                TextStandart {
+                    text: qsTr("Qt Quick Style. Restart to apply.")
+                    Layout.fillWidth: true
+                }
+            }
         }
 
         SettingSection {

--- a/src/welle-gui/gui_helper.cpp
+++ b/src/welle-gui/gui_helper.cpp
@@ -29,6 +29,7 @@
 
 #include <QDebug>
 #include <QSettings>
+#include <QQuickStyle>
 
 #include "gui_helper.h"
 #include "debug_output.h"
@@ -54,6 +55,7 @@ CGUIHelper::CGUIHelper(CRadioController *RadioController, QObject *parent)
     // Add image provider for the MOT slide show
     motImage = new CMOTImageProvider;
 
+    QSettings settings;
     connect(RadioController, &CRadioController::motChanged, this, &CGUIHelper::motUpdate);
     connect(RadioController, &CRadioController::showErrorMessage, this, &CGUIHelper::showErrorMessage);
     connect(RadioController, &CRadioController::showInfoMessage, this, &CGUIHelper::showInfoMessage);
@@ -621,3 +623,153 @@ void FileActivityResultReceiver::handleActivityResult(int receiverRequestCode, i
     }
 }
 #endif
+
+QString CGUIHelper::getQQStyleToLoad(QString styleNameArg)  // Static
+{
+    QSettings settings;
+    QString settingStyle = settings.value("QQStyle","").toString();
+
+    // In case this is a first launch where the setting in the config file is not set
+    if (settingStyle.isEmpty()) {
+        if (styleNameArg.isEmpty()) {
+            settings.setValue("QQStyle", "Default");
+            return "Default";
+        }
+        else {
+            settings.setValue("QQStyle", styleNameArg);
+            return styleNameArg;
+        }
+    }
+
+    QStringList availableStyle = QQuickStyle::availableStyles();
+
+    for ( const QString& curStyle : availableStyle ) {
+         if (settingStyle == curStyle)
+             return settingStyle;
+    }
+    if (settingStyle == "System_Auto")
+        return QString();
+    else
+        return "Default";
+}
+
+const QStringList CGUIHelper::qQStyleComboList()
+{
+    if ( !m_comboList.isEmpty() ) 
+        return m_comboList;
+
+    m_comboList = QQuickStyle::availableStyles();
+    m_comboList.sort();
+    int position = m_comboList.indexOf("Default");
+    m_comboList.move(position, 0);
+    m_comboList.insert(1, "System_Auto");
+
+    QString settingStyle = settings.value("QQStyle","").toString();
+    settingsStyleInAvailableStyles = false;
+
+    for ( const auto& style : m_comboList ) {
+         if (settingStyle == style)
+             settingsStyleInAvailableStyles = true;
+    }
+
+    if ( settingsStyleInAvailableStyles == false ) {
+        m_comboList.append(settingStyle);
+        qDebug() << "Style from the settings " << settingStyle << " not available on system. Adding it to the list of styles and loading 'Default' instead.";
+    }
+
+    return m_comboList;
+}
+
+int CGUIHelper::getIndexOfQQStyle(QString style){
+    //qDebug() << "getIndexOfQQStyle: " << style;
+    return m_comboList.indexOf(style);
+}
+
+QString CGUIHelper::getQQStyle(){
+    return settings.value("QQStyle","").toString();
+}
+
+void CGUIHelper::saveQQStyle(int index) {
+    //qDebug() << "saveQQStyle : " << index;
+    settings.setValue("QQStyle",m_comboList.value(index));
+}
+
+StyleModel::StyleModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+StyleModel* CGUIHelper::qQStyleComboModel()
+{
+    if (m_styleModel != nullptr)
+        m_styleModel = nullptr;
+
+    QString settingStyle = settings.value("QQStyle","").toString();
+
+    QStringList styleList = qQStyleComboList();
+
+    m_styleModel = new StyleModel();
+    for ( const auto& style : styleList  ) {
+        if ( !settingsStyleInAvailableStyles && (settingStyle == style)) {
+            m_styleModel->addStyle(Style(Style(style + tr(" (unavailable, fallback to Default)"), style)));
+        }
+        else {
+            if (style == "System_Auto")
+                m_styleModel->addStyle(Style(tr("Style of system"), style));
+            else if (style == "Default")
+                m_styleModel->addStyle(Style("Default" + tr(" (Recommended)"), style));
+            else
+                m_styleModel->addStyle(Style(style, style));
+        }
+    }
+    return m_styleModel;
+}
+
+QHash<int, QByteArray> StyleModel::roleNames() const
+{
+    QHash<int, QByteArray> roles;
+    roles[LabelRole] = "label";
+    roles[StyleRole] = "style";
+    return roles;
+}
+
+Style::Style(const QString &label, const QString &style)
+    : m_label(label), m_style(style)
+{
+}
+
+QString Style::label() const
+{
+    return m_label;
+}
+
+QString Style::style() const
+{
+    return m_style;
+}
+
+void StyleModel::addStyle(const Style &style)
+{
+    beginInsertRows(QModelIndex(), rowCount(), rowCount());
+    m_styles << style;
+    endInsertRows();
+}
+
+int StyleModel::rowCount(const QModelIndex & parent) const
+{
+    Q_UNUSED(parent);
+    return m_styles.count();
+}
+
+QVariant StyleModel::data(const QModelIndex & index, int role) const
+{
+    if (index.row() < 0 || index.row() >= m_styles.count())
+        return QVariant();
+
+    const Style &style = m_styles[index.row()];
+    if (role == LabelRole)
+        return style.label();
+    else if (role == StyleRole)
+        return style.style();
+    return QVariant();
+}

--- a/src/welle-gui/gui_helper.h
+++ b/src/welle-gui/gui_helper.h
@@ -30,6 +30,8 @@
 #ifndef GUIHELPER_H
 #define GUIHELPER_H
 
+#include <QAbstractListModel>
+#include <QHash>
 #include <QQmlContext>
 #include <QTimer>
 #include <QQmlApplicationEngine>
@@ -54,6 +56,57 @@
     class FileActivityResultReceiver;
 #endif
 
+    
+/*
+ * The Class that described a Style
+ * for use in the Style List Model
+ * It contains 
+ *  - a label which is displayed to the user
+ *  - the technical name of the style for the 
+ *    QQuickStyle::setStyle call
+ */
+class Style
+{
+public:
+    Style(const QString &label, const QString &style);
+    QString label() const;
+    QString style() const;
+
+private:
+    QString m_label;
+    QString m_style;
+};
+
+/*
+ * The Class that stores the ListModel to used to display
+ * the list of styles in a QML ComboBox
+ */
+class StyleModel : public QAbstractListModel
+{
+    Q_OBJECT
+
+public:
+    enum StyleRoles {
+        LabelRole = Qt::UserRole + 1,
+        StyleRole = Qt::UserRole + 2
+    };
+
+    StyleModel(QObject *parent = 0);
+    
+    void addStyle(const Style &style);
+    
+    int rowCount(const QModelIndex & parent = QModelIndex()) const;
+
+    QVariant data(const QModelIndex & index, int role = Qt::DisplayRole) const;
+
+protected:
+    QHash<int, QByteArray> roleNames() const;
+
+private:
+    QList<Style> m_styles;
+};
+
+
 /*
  *	GThe main gui object. It inherits from
  *	QDialog and the generated form
@@ -62,6 +115,8 @@ class CGUIHelper : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QVariant licenses READ licenses CONSTANT)
+    Q_PROPERTY(StyleModel* qQStyleComboModel READ qQStyleComboModel CONSTANT)
+    Q_PROPERTY(QString getQQStyle READ getQQStyle CONSTANT)
 
 public:
     Q_INVOKABLE void addTranslator(QString Language, QObject *obj);
@@ -96,6 +151,14 @@ public:
 
     void setNewDebugOutput(QString text);
 
+    // Qt Quick Style Management methods & members
+    static QString getQQStyleToLoad(QString styleNameArg);
+    const QStringList qQStyleComboList();
+    StyleModel* qQStyleComboModel();
+    QString getQQStyle();
+    Q_INVOKABLE int getIndexOfQQStyle(QString);
+    Q_INVOKABLE void saveQQStyle(int);
+
     CMOTImageProvider* motImage; // ToDo: Must be a getter
 
 private:
@@ -116,6 +179,12 @@ private:
     QVector<QPointF> constellationSeriesData;
 
     const QVariantMap licenses();
+
+    // Qt Quick Style Management methods & members
+    QSettings settings;
+    QStringList m_comboList;
+    StyleModel *m_styleModel = nullptr;
+    bool settingsStyleInAvailableStyles = false;
 
 #ifndef QT_NO_SYSTEMTRAYICON
     QAction *minimizeAction;

--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -102,6 +102,11 @@ int main(int argc, char** argv)
         QCoreApplication::translate("main", "File name"));
     optionParser.addOption(LogFileName);
 
+    QCommandLineOption styleName("qqc-style",
+        QCoreApplication::translate("main", "Qt Quick Controls Style for the 1st launch"),
+        QCoreApplication::translate("main", "style_name"));
+    optionParser.addOption(styleName);
+
     //	Process the actual command line arguments given by the user
     optionParser.process(app);
 
@@ -117,6 +122,14 @@ int main(int argc, char** argv)
     commandLineOptions["dumpFileName"] = optionParser.value(dumpFileName);
 
     CRadioController radioController(commandLineOptions);
+
+    QString styleNameArg = optionParser.value(styleName);
+    //qDebug() << "Command line style_name: " << styleNameArg ;
+    
+    // Set the Qt Quick Style.
+    QString styleToLoad = CGUIHelper::getQQStyleToLoad(styleNameArg);
+    if (!styleToLoad.isEmpty())
+        QQuickStyle::setStyle(styleToLoad);
 
     QSettings settings;
     settings.setValue("version", QString(CURRENT_VERSION));

--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -84,8 +84,6 @@ int main(int argc, char** argv)
     // Set icon
     app.setWindowIcon(QIcon(":/icon/icon.png"));
 
-    QQuickStyle::setStyle("Default");
-
     // Handle the command line
     QCommandLineParser optionParser;
     optionParser.setApplicationDescription("welle.io Help");

--- a/src/welle-gui/resources.qrc
+++ b/src/welle-gui/resources.qrc
@@ -85,6 +85,7 @@
         <file>QML/components/StationListModel.qml</file>
         <file>QML/components/Units.qml</file>
         <file>QML/components/WComboBox.qml</file>
+        <file>QML/components/WComboBoxList.qml</file>
         <file>QML/components/WButton.qml</file>
         <file>QML/components/WSpectrum.qml</file>
         <file>QML/components/qmldir</file>

--- a/src/welle-gui/welle-gui.pro
+++ b/src/welle-gui/welle-gui.pro
@@ -50,6 +50,7 @@ DISTFILES +=    \
     QML/GeneralView.qml \
     QML/settingpages/RawFileSettings.qml \
     QML/components/WComboBox.qml \
+    QML/components/WComboBoxList.qml \
     QML/components/WButton.qml \
     QML/components/WSwitch.qml \
     QML/components/WTumbler.qml \


### PR DESCRIPTION
If the style is not in the settings, it will be set either to "Default" or use the style given with the command line argument "--qqc-style" (if available)

The Style can be selected in the global setting pages. The name stored in the config file is the name of the style, but the GUI displays a label which starts with the style name and some comment like "recommended" which is translated when the language is changed.

If the last used style doesn't exist anymore, it is still displayed with a comment, and not changed until a new style is selected.

Changing the language updated the labels of the combobox.

![select style-v2](https://user-images.githubusercontent.com/46226844/66227935-83361a80-e6de-11e9-8293-2fd6b2b2ab2e.png)
