### PR TITLE
cmake: set welle-io as bundle app under macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,14 @@ cmake_minimum_required(VERSION 3.2)
 
 project(Welle.Io VERSION 0.0.0 LANGUAGES C CXX)
 
+if(NOT WELLE-IO_VERSION)
+  set(WELLE-IO_VERSION ${PROJECT_VERSION})
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 14)
+
+option(WITH_APP_BUNDLE "Enable Application Bundle for macOS" ON)
 
 add_definitions(-Wall)
 add_definitions(-g)
@@ -222,7 +228,25 @@ if(BUILD_WELLE_IO)
       Qt5::Core Qt5::Widgets Qt5::Multimedia Qt5::Charts Qt5::Qml Qt5::Quick Qt5::QuickControls2
     )
 
-    INSTALL (TARGETS ${executableName} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(APPLE AND WITH_APP_BUNDLE)
+        set(macOsIcon ${CMAKE_CURRENT_SOURCE_DIR}/src/welle-gui/icon/icon.icns)
+        set_source_files_properties(${macOsIcon} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+        target_sources(${executableName} PRIVATE ${macOsIcon})
+
+        set(SHORT_VERSION "${WELLE-IO_VERSION}")
+        set(EXECUTABLE "${executableName}")
+        set(TYPEINFO "io.welle.welle")
+        set(PRODUCT_BUNDLE_IDENTIFIER "io.welle.welle")
+
+        set_target_properties("${executableName}" PROPERTIES
+            MACOSX_BUNDLE TRUE
+            MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/welle-io.plist
+        )
+
+        INSTALL (TARGETS ${executableName} BUNDLE DESTINATION ${CMAKE_INSTALL_PREFIX})
+    else()
+        INSTALL (TARGETS ${executableName} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
 endif()
 
 if(BUILD_WELLE_CLI)
@@ -260,21 +284,23 @@ if(BUILD_WELLE_CLI)
                     ${CMAKE_CURRENT_BINARY_DIR}/index.js)
 endif()
 
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/welle-io.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+if(UNIX AND NOT APPLE)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/welle-io.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/16x16/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps)
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/24x24/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps)
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/32x32/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps)
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/48x48/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps)
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/128x128/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps)
-INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/256x256/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/16x16/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/24x24/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/32x32/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/48x48/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/128x128/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps)
+    INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icon/256x256/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps)
 
-INSTALL (
-  FILES
-    ${PROJECT_SOURCE_DIR}/src/welle-cli/index.html
-    ${PROJECT_SOURCE_DIR}/src/welle-cli/index.js
-  DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/welle-io/html/
-)
+    INSTALL (
+        FILES
+          ${PROJECT_SOURCE_DIR}/src/welle-cli/index.html
+          ${PROJECT_SOURCE_DIR}/src/welle-cli/index.js
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/welle-io/html/
+    )
+endif()
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"


### PR DESCRIPTION
Enabled by default, can be disabled with -DWITH_APP_BUNDLE=OFF

Only CMakeLists.txt is changed. see commit 2910b1e 
