### PR TITLE
next: Fix freeze with RTL-SDR when starting scan or playing

### DIFF
--- a/src/input/rtl_sdr.cpp
+++ b/src/input/rtl_sdr.cpp
@@ -168,13 +168,13 @@ void CRTL_SDR::stop(void)
 
     rtlsdrRunning = false;
 
+    if (agcThread.joinable()) {
+        agcThread.join();
+    }
+
     rtlsdr_cancel_async(device);
     if (rtlsdrThread.joinable()) {
         rtlsdrThread.join();
-    }
-
-    if (agcThread.joinable()) {
-        agcThread.join();
     }
 }
 


### PR DESCRIPTION
Seems #431 causes freezes in some situations
See #457 & #436