### PR TITLE
Add option to display station name in the window title

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -56,6 +56,7 @@ ApplicationWindow {
     property bool isExpertView: false
     property bool isFullScreen: false
     property bool isLoaded: false
+    property bool isStationNameInWindowTitle: false
 
     StationListModel { id: stationList }
     StationListModel { id: favoritsList }
@@ -82,6 +83,8 @@ ApplicationWindow {
 
     width: getWidth()
     height: getHeight()
+
+    title: isStationNameInWindowTitle ? radioController.title.trim() + " - welle.io" : "welle.io"
 
     visibility: isFullScreen ? Window.FullScreen : Window.Windowed
 
@@ -456,10 +459,16 @@ ApplicationWindow {
     WDialog {
         id: stationSettingsDialog
         content: Loader {
+            id: stationSettingsLoader
             anchors.right: parent.right
             anchors.left: parent.left
             height: item.implicitHeight
             source:  "qrc:/QML/settingpages/ChannelSettings.qml"
+            onLoaded: isStationNameInWindowTitle = stationSettingsLoader.item.addStationNameToWindowTitleState
+        }
+        Connections {
+            target: stationSettingsLoader.item
+            onAddStationNameToWindowTitleStateChanged : isStationNameInWindowTitle = stationSettingsLoader.item.addStationNameToWindowTitleState
         }
     }
 

--- a/src/welle-gui/QML/settingpages/ChannelSettings.qml
+++ b/src/welle-gui/QML/settingpages/ChannelSettings.qml
@@ -7,10 +7,14 @@ import "../texts"
 import "../components"
 
 Item {
+    id: channelSettingsPage
     implicitHeight: layout.implicitHeight
+
+    property alias addStationNameToWindowTitleState : addStationNameToWindowTitle.checked
 
     Settings {
         property alias enableLastPlayedStationState : enableLastPlayedStation.checked
+        property alias addStationNameToWindowTitleState : channelSettingsPage.addStationNameToWindowTitleState
     }
 
     ColumnLayout{
@@ -23,6 +27,13 @@ Item {
         WSwitch {
             id: enableLastPlayedStation
             text: qsTr("Automatic start playing last station")
+            checked: false
+            Layout.fillWidth: true
+        }
+
+        WSwitch {
+            id: addStationNameToWindowTitle
+            text: qsTr("Display station name in the window title")
             checked: false
             Layout.fillWidth: true
         }


### PR DESCRIPTION
This adds a new toggle button/switch in the channel settings dialog which allows to enable/disable the display station name in the window title.

Replaces #421