### PR TITLE
welle-gui: automatically fit width of Menus to content

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -161,8 +161,9 @@ ApplicationWindow {
                 icon.height: Units.dp(20)
                 onClicked: optionsMenu.open()
 
-                Menu {
+                WMenu {
                     id: optionsMenu
+                    sizeToContents: true
                     x: parent.width - width
                     transformOrigin: Menu.TopRight
 
@@ -250,8 +251,9 @@ ApplicationWindow {
                     onClicked: stationMenu.open()
                     implicitWidth: contentItem.implicitWidth + Units.dp(15)
 
-                    Menu {
+                    WMenu {
                         id: stationMenu
+                        sizeToContents: true
 
                         MenuItem {
                             id: startStationScanItem
@@ -387,8 +389,9 @@ ApplicationWindow {
         visible: isExpertView
         palette.button: "darkorange"
 
-        Menu {
+        WMenu {
             id: viewMenu
+            sizeToContents: true
             transformOrigin: Menu.TopRight
 
             MenuItem {

--- a/src/welle-gui/QML/components/ViewBaseFrame.qml
+++ b/src/welle-gui/QML/components/ViewBaseFrame.qml
@@ -102,8 +102,9 @@ Rectangle {
 
                 onClicked: optionsMenu.open()
 
-                Menu {
+                WMenu {
                     id: optionsMenu
+                    sizeToContents: true
                     x: parent.width - width
                     transformOrigin: Menu.TopRight
 

--- a/src/welle-gui/QML/components/WMenu.qml
+++ b/src/welle-gui/QML/components/WMenu.qml
@@ -1,0 +1,32 @@
+import QtQuick 2.0
+import QtQuick.Controls 2.3
+
+import "../texts"
+
+Menu {
+    id: menu
+    property bool sizeToContents
+    property int menuWidth
+    width: (sizeToContents) ? menuWidth + leftPadding + rightPadding : implicitWidth
+
+    font.pixelSize: TextStyle.textStandartSize
+    font.family: TextStyle.textFont
+
+    onAboutToShow: {
+        var itemwidth = 0;
+        var leftpadding = 0;
+        var rightpadding = 0;
+        
+        for(var i = 0; i < count; i++) {
+            var item = itemAt(i);
+            itemwidth = Math.max(item.contentItem.implicitWidth, itemwidth);
+            leftpadding = Math.max(item.leftPadding, leftpadding);
+            rightpadding = Math.max(item.rightPadding, rightpadding);
+        }
+        menuWidth = Math.ceil(itemwidth + leftpadding + rightpadding);
+        
+        for (var i = 0; i < count; i++) {
+            itemAt(i).width = menuWidth
+        }
+    }
+}

--- a/src/welle-gui/resources.qrc
+++ b/src/welle-gui/resources.qrc
@@ -88,6 +88,7 @@
         <file>QML/components/WComboBoxList.qml</file>
         <file>QML/components/WButton.qml</file>
         <file>QML/components/WSpectrum.qml</file>
+        <file>QML/components/WMenu.qml</file>
         <file>QML/components/qmldir</file>
         <file>QML/expertviews/ServiceDetails.qml</file>
         <file>QML/expertviews/ImpulseResponseGraph.qml</file>

--- a/src/welle-gui/welle-gui.pro
+++ b/src/welle-gui/welle-gui.pro
@@ -55,6 +55,7 @@ DISTFILES +=    \
     QML/components/WSwitch.qml \
     QML/components/WTumbler.qml \
     QML/components/WSpectrum.qml \
+    QML/components/WMenu.qml \
     QML/expertviews/ServiceDetails.qml \
     QML/components/WDialog.qml
 


### PR DESCRIPTION
It can happen that translated text is truncated because menu width is not sufficient.
This PR fixes that