### PR TITLE
Remain compatible with Qt >= 5.10 (MotView)

### DIFF
--- a/src/welle-gui/QML/MotView.qml
+++ b/src/welle-gui/QML/MotView.qml
@@ -1,6 +1,6 @@
 import QtQuick 2.0
 import QtQuick.Layouts 1.3
-import QtQuick.Controls 2.12
+import QtQuick.Controls 2.3
 
 import "components"
 


### PR DESCRIPTION
MotView is not displayed with Qt 5.11
This will allow it to work with Qt >= 5.10