### PR TITLE
add support for rtl_tcp to welle-cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ endif()
 if(BUILD_WELLE_CLI)
     set(cliExecutableName welle-cli)
     add_executable (${cliExecutableName} ${welle_cli_sources} ${backend_sources} ${input_sources} ${fft_sources})
+    add_definitions(-D__CLI__)
 
     if(CMAKE_BUILD_TYPE MATCHES Debug)
       SET_TARGET_PROPERTIES(${cliExecutableName} PROPERTIES COMPILE_FLAGS "-O2 -fno-omit-frame-pointer -fsanitize=address")

--- a/src/input/input_factory.cpp
+++ b/src/input/input_factory.cpp
@@ -128,7 +128,7 @@ CVirtualInput* CInputFactory::GetAutoDevice(RadioControllerInterface& radioContr
     CVirtualInput *inputDevice = nullptr;
 
     // Try to find a input device
-    for (int i = 0; i <= 3; i++) {
+    for (int i = 0; i <= 4; i++) {
         try {
             switch(i) {
 #ifdef HAVE_AIRSPY
@@ -142,6 +142,23 @@ CVirtualInput* CInputFactory::GetAutoDevice(RadioControllerInterface& radioContr
 #endif
 #ifdef __ANDROID__
             case 3: inputDevice = new CAndroid_RTL_SDR(radioController); break;
+#endif
+#ifdef __CLI__
+            case 4: {
+                    inputDevice = new CRTL_TCP_Client(radioController);
+                    CRTL_TCP_Client* RTL_TCP_Client = static_cast<CRTL_TCP_Client*>(inputDevice);
+                    std::string server_addr(getenv("RTL_TCP_IP"));
+                    if (server_addr.empty()) {
+                           server_addr = "127.0.0.1";
+                    }
+                    int server_port = 1234;
+                    if (getenv("RTL_TCP_PORT")) {
+                        server_port = atoi(getenv("RTL_TCP_PORT"));
+                    }
+                    RTL_TCP_Client->setIP(server_addr);
+                    RTL_TCP_Client->setPort(server_port);
+                    break;
+                    }
 #endif
             }
         }


### PR DESCRIPTION
defaults to localhost:1234, environment variables RTL_TCP_IP= and
RTL_TCP_PORT= can be used to configure other servers

GUI can configure this via settings, but cli cannot.
Only problem I can imagine is that now always a rtl_tcp receiver is instanciated, even if there is none at all. But then it is not worse than the previous "nullreceiver" case ;-)