### PR TITLE
welle-cli: fix webradiointerface's send_slide

### DIFF
--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -927,7 +927,7 @@ bool WebRadioInterface::send_slide(Socket& s, const std::string& stream)
             headers << "\r\n";
             const auto headers_str = headers.str();
             int ret = s.send(headers_str.data(), headers_str.size(), MSG_NOSIGNAL);
-            if (ret == 0) {
+            if (ret == (ssize_t)headers_str.size()) {
                 ret = s.send(mot.data.data(), mot.data.size(), MSG_NOSIGNAL);
             }
 


### PR DESCRIPTION
Socket::send returns the number of bytes sent on success, not 0.

Slide download in the webradiointerface is broken right now.