### PR TITLE
welle-gui: Use LightGrey text color when using Dark theme

### DIFF
--- a/src/welle-gui/QML/components/StationDelegate.qml
+++ b/src/welle-gui/QML/components/StationDelegate.qml
@@ -41,6 +41,8 @@
 import QtQuick 2.2
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.3
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Universal 2.1
 
 // Import custom styles
 import "../texts"
@@ -62,7 +64,7 @@ Item {
 
     Rectangle {
         anchors.fill: parent
-        color: "lightgrey"
+        color: (mainWindow.Material.theme === Material.Dark ) ? "dimgrey" : (mainWindow.Universal.theme === Universal.Dark ) ? "dimgrey" : "lightgrey"
         visible: mouse.pressed
     }
 

--- a/src/welle-gui/QML/components/WSwitch.qml
+++ b/src/welle-gui/QML/components/WSwitch.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.6
 import QtQuick.Controls 2.0
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Universal 2.1
 
 // Import custom styles
 import "../texts"
@@ -15,6 +17,7 @@ Switch {
     contentItem: Text {
               text: wSwitch.text
               font: wSwitch.font
+              color: (mainWindow.Material.theme === Material.Dark ) ? "lightgrey" : (mainWindow.Universal.theme === Universal.Dark ) ? "lightgrey" : TextStyle.textColor
               verticalAlignment: Text.AlignVCenter
               wrapMode: Text.WordWrap
               leftPadding: wSwitch.indicator.width + wSwitch.spacing

--- a/src/welle-gui/QML/texts/TextStandart.qml
+++ b/src/welle-gui/QML/texts/TextStandart.qml
@@ -1,4 +1,6 @@
 import QtQuick 2.0
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Universal 2.1
 
 // Import custom styles
 import "."
@@ -6,6 +8,6 @@ import "."
 Text {
     font.pixelSize: TextStyle.textStandartSize
     font.family: TextStyle.textFont
-    //color: TextStyle.textColor
+    color: (mainWindow.Material.theme === Material.Dark ) ? "lightgrey" : (mainWindow.Universal.theme === Universal.Dark ) ? "lightgrey" : TextStyle.textColor
     wrapMode: Text.WordWrap
 }

--- a/src/welle-gui/QML/texts/TextStation.qml
+++ b/src/welle-gui/QML/texts/TextStation.qml
@@ -1,4 +1,6 @@
 import QtQuick 2.0
+import QtQuick.Controls.Material 2.1
+import QtQuick.Controls.Universal 2.1
 
 // Import custom styles
 import "."
@@ -6,5 +8,5 @@ import "."
 Text {
     font.pixelSize: TextStyle.textStation
     font.family: TextStyle.textFont
-    //color: TextStyle.textColor
+    color: (mainWindow.Material.theme === Material.Dark ) ? "lightgrey" : (mainWindow.Universal.theme === Universal.Dark ) ? "lightgrey" : TextStyle.textColor
 }

--- a/src/welle-gui/QML/texts/TextStyle.qml
+++ b/src/welle-gui/QML/texts/TextStyle.qml
@@ -16,5 +16,5 @@ QtObject {
     property string textFont: "Arial"
     //property string textFont: "Times"
     //property color textColor: "white"
-    //property color textColor: "black"
+    property color textColor: "black"
 }


### PR DESCRIPTION
Sets font color to lightgrey for
- station list
- switch labels
- the combobox values

See #499 for screenshots