### PR TITLE
Fix translation issues

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -172,7 +172,7 @@ ApplicationWindow {
                         text: qsTr("Settings")
                         font.pixelSize: TextStyle.textStandartSize
                         onTriggered: {
-                            globalSettingsDialog.title = text
+                            globalSettingsDialog.title = "Settings"
                             globalSettingsDialog.open()
                         }
                     }
@@ -180,7 +180,7 @@ ApplicationWindow {
                         text: qsTr("Expert Settings")
                         font.pixelSize: TextStyle.textStandartSize
                         onTriggered: {
-                            expertSettingsDialog.title = text
+                            expertSettingsDialog.title = "Expert Settings"
                             expertSettingsDialog.open()
                         }
                     }
@@ -188,7 +188,7 @@ ApplicationWindow {
                         text: qsTr("About")
                         font.pixelSize: TextStyle.textStandartSize
                         onTriggered: {
-                            aboutDialog.title = text
+                            aboutDialog.title = "About"
                             aboutDialog.open()
                         }
                     }
@@ -296,7 +296,7 @@ ApplicationWindow {
                             font.pixelSize: TextStyle.textStandartSize
                             font.family: TextStyle.textFont
                             onTriggered: {
-                                stationSettingsDialog.title = text
+                                stationSettingsDialog.title = "Station settings"
                                 stationSettingsDialog.open()
                             }
                         }

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -248,7 +248,7 @@ ViewBaseFrame {
             Layout.alignment: Qt.AlignLeft
             Layout.leftMargin: Units.dp(5)
             verticalAlignment: Text.AlignBottom
-            text: radioController.stationType
+            text: qsTranslate("DABConstants", radioController.stationType)
         }
 
         TextRadioInfo {

--- a/src/welle-gui/QML/components/WDialog.qml
+++ b/src/welle-gui/QML/components/WDialog.qml
@@ -36,7 +36,7 @@ Dialog {
                    font.pixelSize: TextStyle.textStandartSize
                    font.family: TextStyle.textFont
 
-                   text: title
+                   text: qsTranslate("MainView", title)
                    elide: Label.ElideRight
                    horizontalAlignment: Qt.AlignHCenter
                    verticalAlignment: Qt.AlignVCenter

--- a/src/welle-gui/QML/settingpages/GlobalSettings.qml
+++ b/src/welle-gui/QML/settingpages/GlobalSettings.qml
@@ -95,7 +95,7 @@ Item {
                     sizeToContents: true
                     onCurrentIndexChanged: {
                         // Load appropriate settings
-                        guiHelper.updateTranslator(listModel.get(currentIndex).langCode, this); 
+                        guiHelper.updateTranslator(listModel.get(currentIndex).langCode, mainWindow);
                     }
                 }
 

--- a/src/welle-gui/gui_helper.cpp
+++ b/src/welle-gui/gui_helper.cpp
@@ -30,6 +30,7 @@
 #include <QDebug>
 #include <QSettings>
 #include <QQuickStyle>
+#include <QQmlProperty>
 
 #include "gui_helper.h"
 #include "debug_output.h"
@@ -644,10 +645,20 @@ void CGUIHelper::translateGUI(QString Language, QObject *obj)
     QLocale curLocale(QLocale((const QString&)Language));
     QLocale::setDefault(curLocale);
 
+    // Save previous width & height
+    // (because they are reset by the call to retranslate())
+    QVariant width = QQmlProperty::read(obj, "width");
+    QVariant height = QQmlProperty::read(obj, "height");
+
     // Start translation of GUI
     QQmlContext *currentContext = QQmlEngine::contextForObject(obj);
     QQmlEngine *engine = currentContext->engine();
     engine->retranslate();
+
+    // Restore previous width & height
+    // (because they are reset by the call to retranslate())
+    QQmlProperty::write(obj, "width", width);
+    QQmlProperty::write(obj, "height", height);
 
     // Start translation of non-QML GUI
 #ifndef QT_NO_SYSTEMTRAYICON

--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -782,10 +782,10 @@ void CRadioController::stationTimerTimeout()
                         qDebug() << "Selecting service failed";
                     }
                     else {
-                        currentStationType = QCoreApplication::translate("DABConstants",(DABConstants::getProgramTypeName(s.programType)));
+                        currentStationType = DABConstants::getProgramTypeName(s.programType);
                         emit stationTypChanged();
 
-                        currentLanguageType = QCoreApplication::translate("DABConstants",(DABConstants::getLanguageName(s.language)));
+                        currentLanguageType = DABConstants::getLanguageName(s.language);
                         emit languageTypeChanged();
 
                         bitRate = subch.bitrate();


### PR DESCRIPTION
Fix these 3 issues related to translations reported by andimik in https://github.com/AlbrechtL/welle.io/issues/506#issuecomment-594791084
- when changing the language the window resizes
- After switching to another language the PTy is not updated to the new language (e. g. Reiseinformation keeps it in English)
- same with the window title label "Einstellungen" (the rest of the settings menu gets the new language)
