### PR TITLE
gui: improve WComboBoxList translation

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -224,14 +224,18 @@ ApplicationWindow {
             anchors.topMargin: Units.dp(5)
 
             RowLayout {
-                WComboBox {
+                WComboBoxList {
                     id: stationListBox
+                    textRole: 'trLabel'
+                    model: ListModel {
+                        id: stationListBoxModel
+                        ListElement { label: "All stations"; trLabel: qsTr("All stations"); trContext: "MainView" }
+                        ListElement { label: "Favorites"; trLabel: qsTr("Favorites"); trContext: "MainView" }
+                    }
                     sizeToContents: true
 //                    background: Rectangle {
 //                        color: "white"
 //                    }
-
-                    model:  [qsTr("All stations"), qsTr("Favorites")]
 
                     onCurrentIndexChanged: {
                         switch(currentIndex) {

--- a/src/welle-gui/QML/components/WComboBoxList.qml
+++ b/src/welle-gui/QML/components/WComboBoxList.qml
@@ -18,7 +18,7 @@ ComboBox {
     delegate: ItemDelegate {
         width: comboBox.width
         contentItem: TextStandart {
-            text: label;
+            text: typeof trContext !== "undefined" ? qsTranslate(trContext, label) : label
             elide: Text.ElideRight
             verticalAlignment: Text.AlignVCenter
         }
@@ -29,11 +29,51 @@ ComboBox {
         id: textMetrics
     }
 
+    onCurrentIndexChanged: {
+        // Update the translation of selected item label, otherwise
+        // it is not updated (in the case we previously changed the language)
+        updateTrLabel()
+    }
+
     onModelChanged: {
+        computeComboBoxWidth()
+    }
+
+    function computeComboBoxWidth() {
         textMetrics.font = comboBox.font
         for(var i = 0; i < model.count; i++){
-            textMetrics.text = model.get(i).label
+            var label;
+            if (typeof model.get(i).trContext !== "undefined") {
+                label = qsTranslate(model.get(i).trContext, model.get(i).label);
+            } else {
+                label = model.get(i).label;
+            }
+            textMetrics.text = label
             modelWidth = Math.max(textMetrics.width, modelWidth)
+        }
+        //console.debug("ComboBox width: " + modelWidth)
+    }
+
+    function updateTrLabel() {
+        if (model) {
+            var item = model.get(currentIndex)
+            if (item.trLabel && item.trContext) {
+                var trLbl = qsTranslate(item.trContext, item.label);
+                //console.debug("[Translate] Index: " + currentIndex + " - Value:" + trLbl)
+                model.setProperty(currentIndex, "trLabel", trLbl);
+            }
+        }
+    }
+
+    Connections {
+        target: guiHelper
+        onTranslationFinished: {
+            modelWidth = 0;
+            computeComboBoxWidth()
+
+            // Update the translation of selected item label, otherwise
+            // it stays in the previous language
+            updateTrLabel()
         }
     }
 }

--- a/src/welle-gui/QML/settingpages/ExpertSettings.qml
+++ b/src/welle-gui/QML/settingpages/ExpertSettings.qml
@@ -59,10 +59,16 @@ Item {
             RowLayout {
                 enabled: disableCoarse.checked
 
-                WComboBox {
+                WComboBoxList {
                     id: freqSyncMethodBox
+                    textRole: 'trLabel'
+                    model: ListModel {
+                        id: freqSyncMethodBoxModel
+                        ListElement { label: "GetMiddle"; trLabel: qsTr("GetMiddle"); trContext: "ExpertSettings" }
+                        ListElement { label: "CorrelatePRS"; trLabel: qsTr("CorrelatePRS"); trContext: "ExpertSettings" }
+                        ListElement { label: "PatternOfZeros"; trLabel: qsTr("PatternOfZeros"); trContext: "ExpertSettings" }
+                    }
                     sizeToContents: true
-                    model: [ qsTr("GetMiddle"), qsTr("CorrelatePRS"), qsTr("PatternOfZeros") ];
                     currentIndex: 1
                     onCurrentIndexChanged: {
                         radioController.setFreqSyncMethod(currentIndex)
@@ -91,10 +97,16 @@ Item {
 
             RowLayout {
                 Layout.fillWidth: true
-                WComboBox {
+                WComboBoxList {
                     id: fftPlacementBox
+                    textRole: 'trLabel'
+                    model: ListModel {
+                        id: fftPlacementBoxModel
+                        ListElement { label: "Strongest Peak"; trLabel: qsTr("Strongest Peak"); trContext: "ExpertSettings" }
+                        ListElement { label: "Earliest Peak With Binning"; trLabel: qsTr("Earliest Peak With Binning"); trContext: "ExpertSettings" }
+                        ListElement { label: "Threshold Before Peak"; trLabel: qsTr("Threshold Before Peak"); trContext: "ExpertSettings" }
+                    }
                     sizeToContents: true
-                    model: [ qsTr("Strongest Peak"), qsTr("Earliest Peak With Binning"), qsTr("Threshold Before Peak") ];
                     currentIndex: 1
                     onCurrentIndexChanged: {
                         radioController.selectFFTWindowPlacement(currentIndex)

--- a/src/welle-gui/QML/settingpages/GlobalSettings.qml
+++ b/src/welle-gui/QML/settingpages/GlobalSettings.qml
@@ -167,12 +167,22 @@ Item {
                 checked: true
             }
 
-            WComboBox {
+            WComboBoxList {
                 id: deviceBox
                 enabled: !enableAutoSdr.checked
                 Layout.fillWidth: true
-                // Note: Adding the translation option qsTr() into the device names are forcing to change the model which results in a currentIndex of 0 (Null device)
-                model: [ "None", "Airspy", "rtl-sdr", "SoapySDR", "rtl-tcp", "RAW file"];
+
+                textRole: 'trLabel'
+                model: ListModel {
+                    id: deviceBoxModel
+                    ListElement { label: "None"; trLabel: qsTr("None"); trContext: "GlobalSettings" }
+                    ListElement { label: "Airspy"; trLabel: qsTr("Airspy"); trContext: "GlobalSettings" }
+                    ListElement { label: "rtl-sdr"; trLabel: qsTr("rtl-sdr"); trContext: "GlobalSettings" }
+                    ListElement { label: "SoapySDR"; trLabel: qsTr("SoapySDR"); trContext: "GlobalSettings" }
+                    ListElement { label: "rtl-tcp"; trLabel: qsTr("rtl-tcp"); trContext: "GlobalSettings" }
+                    ListElement { label: "RAW file"; trLabel: qsTr("RAW file"); trContext: "GlobalSettings" }
+                }
+
                 onCurrentIndexChanged: {
                     // Load appropriate settings
                     switch(currentIndex) {
@@ -235,12 +245,12 @@ Item {
                     id: qQStyleTheme
                     sizeToContents: true
                     enabled: guiHelper.isThemableStyle(guiHelper.getQQStyle)
-                    textRole: 'label'
+                    textRole: 'trLabel'
                     model: ListModel {
                         id: themeListModel
-                        ListElement { label: qsTr("Light"); themeCode: "Light" }
-                        ListElement { label: qsTr("Dark"); themeCode: "Dark" }
-                        ListElement { label: qsTr("System"); themeCode: "System" }
+                        ListElement { label: "Light"; trLabel: qsTr("Light"); trContext: "GlobalSettings" }
+                        ListElement { label: "Dark"; trLabel: qsTr("Dark"); trContext: "GlobalSettings" }
+                        ListElement { label: "System"; trLabel: qsTr("System"); trContext: "GlobalSettings" }
                     }
                 }
                 TextStandart {
@@ -255,7 +265,5 @@ Item {
                 }
             }
         }
-
-
     }
 }

--- a/src/welle-gui/gui_helper.cpp
+++ b/src/welle-gui/gui_helper.cpp
@@ -656,6 +656,8 @@ void CGUIHelper::translateGUI(QString Language, QObject *obj)
     restoreAction->setText(tr("&Restore"));
     quitAction->setText(tr("&Quit"));
 #endif
+
+    emit translationFinished();
 }
 
 #ifdef __ANDROID__

--- a/src/welle-gui/gui_helper.h
+++ b/src/welle-gui/gui_helper.h
@@ -231,6 +231,7 @@ signals:
     void newDebugOutput(QString text);
     void newDeviceId(int deviceId);
     void styleChanged(void);
+    void translationFinished(void);
 
 #ifndef QT_NO_SYSTEMTRAYICON
     void minimizeWindow(void);


### PR DESCRIPTION
* WComboBoxList: better support for label translations and update width
  in case labels of the combobox are translated
* Transformed some WComboBox to WComboBoxList items
* This will fix translation issues in various WComboBox components
  that use translation  by using WComboBoxList instead.
  For exemple " Note: Adding the translation option qsTr() into the device names
      are forcing to change the model which results in a currentIndex
      of 0 (Null device) " which happened on other WComboBox using qsTr().
  This is now fixed