### PR TITLE
welle-io: update autoChannel & autoService on new station selection in GUI

### DIFF
--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -261,6 +261,7 @@ void CRadioController::setService(uint32_t service, bool force)
 {
     if (currentService != service or force) {
         currentService = service;
+        autoService = service;
         emit stationChanged();
 
         // Wait if we found the station inside the signal
@@ -299,12 +300,14 @@ void CRadioController::setChannel(QString Channel, bool isScan, bool Force)
     if (currentChannel != Channel || Force == true) {
         if (device && device->getID() == CDeviceID::RAWFILE) {
             currentChannel = "File";
+            autoChannel = currentChannel;
             currentEId = 0;
             currentEnsembleLabel = "";
             currentFrequency = 0;
         }
         else { // A real device
             currentChannel = Channel;
+            autoChannel = currentChannel;
             currentEId = 0;
             currentEnsembleLabel = "";
 


### PR DESCRIPTION
* Otherwise, they are only set a startup time, and if one changes
  the device while having autoPlay enabled, then it will start
  playing the service/station that was launched at startup, and not
  the last running service/station.