### PR TITLE
gui: take autoplay immediately into account (and not only after restart)

### DIFF
--- a/src/welle-gui/QML/settingpages/ChannelSettings.qml
+++ b/src/welle-gui/QML/settingpages/ChannelSettings.qml
@@ -29,6 +29,7 @@ Item {
             text: qsTr("Automatic start playing last station")
             checked: false
             Layout.fillWidth: true
+            onClicked: radioController.setAutoPlay(checked, radioController.lastChannel[1], radioController.lastChannel[0])
         }
 
         WSwitch {

--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -139,12 +139,10 @@ int main(int argc, char** argv)
     settings.setValue("version", QString(CURRENT_VERSION));
 
     // Should we play the last station we have listened to previously?
-    if( settings.value("enableLastPlayedStationState", false).toBool() ) {
-
-        QStringList lastStation = settings.value("lastchannel").toStringList();
-        if( lastStation.count() == 2 )
-            radioController.setAutoPlay(lastStation[1], lastStation[0]);
-    }
+    bool isAutoPlay = settings.value("enableLastPlayedStationState", false).toBool();
+    QStringList lastStation = settings.value("lastchannel").toStringList();
+    if( lastStation.count() == 2 )
+        radioController.setAutoPlay(isAutoPlay, lastStation[1], lastStation[0]);
 
     // Load mandatory driver arguments to init input device
     radioController.setDeviceParam("SoapySDRDriverArgs", settings.value("soapyDriverArgs","").toString());

--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -241,8 +241,9 @@ void CRadioController::play(QString channel, QString title, quint32 service)
     setChannel(channel, false);
     setService(service);
 
+    currentLastChannel = QStringList() << serialise_serviceid(service) << channel;
     QSettings settings;
-    settings.setValue("lastchannel", QStringList() << serialise_serviceid(service) << channel);
+    settings.setValue("lastchannel", currentLastChannel);
 }
 
 void CRadioController::stop()
@@ -280,11 +281,12 @@ void CRadioController::setService(uint32_t service, bool force)
     }
 }
 
-void CRadioController::setAutoPlay(QString channel, QString service)
+void CRadioController::setAutoPlay(bool isAutoPlayValue, QString channel, QString service)
 {
-    isAutoPlay = true;
+    isAutoPlay = isAutoPlayValue;
     autoChannel = channel;
     autoService = deserialise_serviceid(service.toStdString().c_str());
+    currentLastChannel = QStringList() << service << channel;
 }
 
 void CRadioController::setVolume(qreal Volume)

--- a/src/welle-gui/radio_controller.h
+++ b/src/welle-gui/radio_controller.h
@@ -83,6 +83,7 @@ class CRadioController :
     Q_PROPERTY(QString errorMsg MEMBER errorMsg NOTIFY showErrorMessage)
 
     Q_PROPERTY(QString channel MEMBER currentChannel NOTIFY channelChanged)
+    Q_PROPERTY(QStringList lastChannel MEMBER currentLastChannel NOTIFY lastChannelChanged)
     Q_PROPERTY(QString ensemble MEMBER currentEnsembleLabel NOTIFY ensembleChanged)
     Q_PROPERTY(int frequency MEMBER currentFrequency NOTIFY frequencyChanged)
     Q_PROPERTY(quint32 service MEMBER currentService NOTIFY stationChanged)
@@ -110,7 +111,7 @@ public:
     Q_INVOKABLE void setManualChannel(QString Channel);
     Q_INVOKABLE void startScan(void);
     Q_INVOKABLE void stopScan(void);
-    void setAutoPlay(QString channel, QString serviceid_as_string);
+    Q_INVOKABLE void setAutoPlay(bool isAutoPlayValue, QString channel, QString serviceid_as_string);
     Q_INVOKABLE void setVolume(qreal volume);
     Q_INVOKABLE void setAGC(bool isAGC);
     Q_INVOKABLE void disableCoarseCorrector(bool disable);
@@ -193,6 +194,7 @@ private:
     int stationCount = 0;
 
     QString currentChannel;
+    QStringList currentLastChannel;
     std::list<uint32_t> pendingLabels;
     QString currentEnsembleLabel;
     uint16_t currentEId;
@@ -271,6 +273,7 @@ signals:
     void motReseted(void);
 
     void channelChanged();
+    void lastChannelChanged();
     void ensembleChanged();
     void frequencyChanged();
     void stationChanged();


### PR DESCRIPTION
* If one changes the autoplay value in the GUI, the new value is not
  taken into account before welle-gui is restarted. This can be a problem
  if one changes the device or parameters of the device (leading in the
  new autoPlay option not beeing honored)
  This will fix this issue.