### PR TITLE
gui: add the "(Language)" suffix to the language label

### DIFF
--- a/src/welle-gui/QML/settingpages/GlobalSettings.qml
+++ b/src/welle-gui/QML/settingpages/GlobalSettings.qml
@@ -100,7 +100,7 @@ Item {
                 }
 
                 TextStandart {
-                    text: qsTr("Language")
+                    text: qsTr("Language") == "Language" ? "Language" : qsTr("Language") + " (Language)"
                     Layout.fillWidth: true
                 }
             }


### PR DESCRIPTION
add the "(Language)" suffix to the language label (only if the label is not already "Language")

![well io-language](https://user-images.githubusercontent.com/46226844/77851114-6edb6200-71d7-11ea-8fd2-13f51402cd5c.png)
