### PR TITLE
gui: add "File" label to translatable strings

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -323,7 +323,7 @@ ApplicationWindow {
                 delegate: StationDelegate {
                     stationNameText: stationName
                     stationSIdValue: stationSId
-                    channelNameText: channelName
+                    channelNameText: channelName == "File" ? qsTr("File") : channelName
                     isFavorit: favorit
                     isExpert: isExpertView
                     onClicked: radioController.play(channelName, stationName, stationSId)


### PR DESCRIPTION
* "File" is displayed in the list of channels when expert view is enabled