### PR TITLE
welle-cli: display build and link to github and welle.io

### DIFF
--- a/src/welle-cli/index.html
+++ b/src/welle-cli/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>welle-io web</title>
+        <title>welle-cli webfrontend</title>
         <meta charset="UTF-8">
 <style>
 body {
@@ -129,7 +129,7 @@ canvas {
             <div id="block_tii" class="block_graph">
                 <div class="title"><div class="chevron"></div><h2>TII Info</h2></div>
                 <div class="data" style="display: none" id="tiiinfo"></div>
-            </div>
+            </div>   
 
         </div>
         <div>
@@ -144,5 +144,7 @@ canvas {
         </div>
 
         <script type="text/javascript" src="/index.js"></script>
+        
+        <div align="center"><p>welle.io and welle-cli is DAB and DAB+ software defined radio (SDR). For more information visit <a href="https://github.com/AlbrechtL/welle.io/">https://github.com/AlbrechtL/welle.io/</a> and <a href="https://www.welle.io">https://www.welle.io</a></p></div>
     </body>
 </html>

--- a/src/welle-cli/index.js
+++ b/src/welle-cli/index.js
@@ -146,7 +146,9 @@ var ensembleInfoTimer = setInterval(populateEnsembleinfo, 1000);
 
 function ensembleInfoTemplate() {
     var html = '';
-    html += ' <h1>FIG1: ${label} (${shortlabel}) FIG2: ${fig2label}</h1>';
+    html += ' <h1><abbr title="Ensemble long and short labels defined in FIG1">${label} (${shortlabel})</abbr></h1>';
+    html += ' <h2><abbr title="Ensemble long and short labels defined in FIG2">${fig2label}</abbr></h2>';
+    html += ' <div align="right"><p><abbr title="${hw_name}, ${sw_name}">This is welle-cli build version ${version}</abbr></p></div>';
     html += ' <table id="servicetable">';
     html += ' <tr><th>Ensemble ID </th>';
     html += ' <th>ECC </th>';
@@ -410,6 +412,9 @@ function populateEnsembleinfo() {
         document.getElementById("fftwindowselector").value = data.receiver.software.fftwindowplacement;
         document.getElementById("coarsecheckbox").checked = data.receiver.software.coarsecorrectorenabled;
 
+        ens["version"] = data.receiver.software.version;
+        ens["hw_name"] = data.receiver.hardware.name;
+        ens["sw_name"] = data.receiver.software.name;
         ens["SNR"] = data.demodulator.snr;
         ens["FrequencyCorrection"] = data.demodulator.frequencycorrection;
         ens["services"] = servicehtml;


### PR DESCRIPTION
* Added missing fields (build version, software name, hardware name) which were in JSON, but not in the web frontend
* changed title to welle-cli
* added link to this GitHub project and to the welle.io homepage
* added mouse over effect for FIG1 and (optional) FIG2 ensemble labels