### PR TITLE
audio: don't start audio output at startup

### DIFF
--- a/src/welle-gui/audio_output.cpp
+++ b/src/welle-gui/audio_output.cpp
@@ -110,7 +110,9 @@ void CAudioThread::init(int sampleRate)
     connect(audioOutput, &QAudioOutput::stateChanged, this, &CAudioThread::handleStateChanged);
 
     audioIODevice.start();
-    audioOutput->start(&audioIODevice);
+
+    // Disable audio at startup. It will be started through "checkAudioBufferTimeout" method when needed
+    //audioOutput->start(&audioIODevice);
 }
 
 void CAudioThread::run()

--- a/src/welle-gui/audio_output.h
+++ b/src/welle-gui/audio_output.h
@@ -79,7 +79,7 @@ class CAudioThread: public QThread
         QAudioOutput *audioOutput = nullptr;
         QAudioDeviceInfo *info = nullptr;
         QTimer checkAudioBufferTimer;
-        QAudio::State currentState;
+        QAudio::State currentState = QAudio::StoppedState;
         int32_t cardRate;
 
     signals:


### PR DESCRIPTION
* Audio output is already started through "checkAudioBufferTimeout" method when
there is really something to play
* This permits to avoid unnecessary CPU load
For example, on linux it reduces CPU load on process "pulseaudio" when no station is played
* Moreover it removes the "speaker" icon that was displayed by error in welle-io's item of taskbar (this icon which is usually displayed only when there is really something playing used to be here even if nothing was played in welle-io)