### PR TITLE
gui: add font settings

### DIFF
--- a/src/welle-gui/QML/InfoPage.qml
+++ b/src/welle-gui/QML/InfoPage.qml
@@ -4,6 +4,7 @@ import QtQuick.Controls 2.0
 
 // Import custom styles
 import "texts"
+import "components"
 
 Item {
     id: infoPage
@@ -81,6 +82,8 @@ Item {
             TextStandart {
                 id: fileContent
                 text: guiHelper.getInfoPage("Versions")
+                font.family: TextStyle.textFontFixed
+                font.pixelSize: Units.em(0.9)
                 Layout.alignment: Qt.AlignLeft
                 wrapMode: Text.Wrap
                 width: parent.width - scrollbar.width

--- a/src/welle-gui/QML/components/WComboBox.qml
+++ b/src/welle-gui/QML/components/WComboBox.qml
@@ -9,7 +9,10 @@ ComboBox {
 
     property bool sizeToContents
     property int modelWidth
-    width: (sizeToContents) ? modelWidth + 2*leftPadding + 2*rightPadding : implicitWidth
+    width: (sizeToContents) ?
+        Math.min(parent.width,
+                 modelWidth + comboBox.leftPadding + comboBox.rightPadding + contentItem.leftPadding + contentItem.rightPadding)
+        : implicitWidth
     Layout.preferredWidth: width
 
     font.pixelSize: TextStyle.textStandartSize
@@ -29,11 +32,23 @@ ComboBox {
         id: textMetrics
     }
 
-    onModelChanged: {
+    Component.onCompleted: computeComboBoxWidth()
+
+    function computeComboBoxWidth() {
+        modelWidth = 0
         textMetrics.font = comboBox.font
         for(var i = 0; i < model.length; i++){
             textMetrics.text = model[i]
             modelWidth = Math.max(textMetrics.width, modelWidth)
         }
+    }
+
+    onModelChanged: {
+        computeComboBoxWidth()
+    }
+
+    Connections {
+        target: globalSettingsLoader.item
+        onFontChanged: computeComboBoxWidth()
     }
 }

--- a/src/welle-gui/QML/components/WComboBoxList.qml
+++ b/src/welle-gui/QML/components/WComboBoxList.qml
@@ -9,7 +9,9 @@ ComboBox {
 
     property bool sizeToContents
     property int modelWidth
-    width: (sizeToContents) ? modelWidth + 2*leftPadding + 2*rightPadding : implicitWidth
+    width: (sizeToContents) ?
+        modelWidth + comboBox.leftPadding + comboBox.rightPadding + contentItem.leftPadding + contentItem.rightPadding
+        : implicitWidth
     Layout.preferredWidth: width
 
     font.pixelSize: TextStyle.textStandartSize
@@ -29,6 +31,8 @@ ComboBox {
         id: textMetrics
     }
 
+    Component.onCompleted: computeComboBoxWidth()
+
     onCurrentIndexChanged: {
         // Update the translation of selected item label, otherwise
         // it is not updated (in the case we previously changed the language)
@@ -40,6 +44,7 @@ ComboBox {
     }
 
     function computeComboBoxWidth() {
+        modelWidth = 0
         textMetrics.font = comboBox.font
         for(var i = 0; i < model.count; i++){
             var label;
@@ -68,12 +73,15 @@ ComboBox {
     Connections {
         target: guiHelper
         onTranslationFinished: {
-            modelWidth = 0;
             computeComboBoxWidth()
 
             // Update the translation of selected item label, otherwise
             // it stays in the previous language
             updateTrLabel()
         }
+    }
+    Connections {
+        target: globalSettingsLoader.item
+        onFontChanged: computeComboBoxWidth()
     }
 }

--- a/src/welle-gui/QML/expertviews/TextOutputView.qml
+++ b/src/welle-gui/QML/expertviews/TextOutputView.qml
@@ -38,7 +38,7 @@ ViewBaseFrame {
 
             TextArea.flickable: TextArea {
                 id: textField
-                font.family: "Monospace"
+                font.family: TextStyle.textFontFixed
                 font.pixelSize: Units.em(0.9)
                 background: Rectangle { color: "black" }
                 color: "white"

--- a/src/welle-gui/QML/settingpages/GlobalSettings.qml
+++ b/src/welle-gui/QML/settingpages/GlobalSettings.qml
@@ -13,6 +13,7 @@ Item {
     property alias enableFullScreenState : enableFullScreen.checked
     property alias qQStyleTheme : qQStyleTheme.currentIndex
     property bool isLoaded: false
+    signal fontChanged()
 
     anchors.fill: parent
     implicitHeight: layout.implicitHeight
@@ -26,6 +27,10 @@ Item {
         property alias enableAutoSdr : enableAutoSdr.checked
         property alias languageValue : languageBox.currentIndex
         property alias qQStyleTheme: qQStyleTheme.currentIndex
+        property alias fontGeneralSystemSwitchState: fontGeneralSystemSwitch.checked
+        property alias fontGeneral: fontSettings.fontGeneralName
+        property alias fontFixedSystemSwitchState: fontFixedSystemSwitch.checked
+        property alias fontFixed: fontSettings.fontFixedName
     }
 
     Component.onCompleted: {
@@ -263,6 +268,97 @@ Item {
                         qQStyleTheme.enabled = guiHelper.isThemableStyle(guiHelper.getQQStyle)
                     }
                 }
+            }
+        }
+        SettingSection {
+            id: fontSettings
+
+            property var fontList: Qt.fontFamilies()
+            property string fontGeneralName
+            property string fontFixedName
+
+            text: qsTr("Font settings")
+
+            WSwitch {
+                id: fontGeneralSystemSwitch
+                text: qsTr("General font: use system font")
+                Layout.fillWidth: true
+                checked: true
+                onCheckedChanged: fontSettings.setFontGeneral()
+            }
+            WComboBox {
+                id: fontGeneralBox
+                sizeToContents: true
+                enabled: !fontGeneralSystemSwitch.checked
+                model: fontSettings.fontList
+                onCurrentIndexChanged: {
+                    if (fontSettings.fontGeneralName === undefined ||
+                        fontSettings.fontGeneralName === "" ||
+                        fontSettings.fontList.indexOf(fontSettings.fontGeneralName) === -1)
+                    {
+                        fontSettings.fontGeneralName = guiHelper.systemFontGeneral
+                        currentIndex = fontSettings.fontList.indexOf(fontSettings.fontGeneralName)
+                    }
+                    else
+                    {
+                        fontSettings.fontGeneralName = model[currentIndex]
+                    }
+                    fontSettings.setFontGeneral()
+                }
+                Component.onCompleted: {
+                    currentIndex = fontSettings.fontList.indexOf(fontSettings.fontGeneralName)
+                    fontSettings.setFontGeneral()
+                }
+            }
+            function setFontGeneral() {
+                if (fontGeneralSystemSwitch.checked) {
+                    TextStyle.textFont = guiHelper.systemFontGeneral
+                } else {
+                    TextStyle.textFont = fontSettings.fontGeneralName
+                }
+                fontChanged()
+                console.debug("General font set to: " + TextStyle.textFont)
+            }
+
+
+            WSwitch {
+                id: fontFixedSystemSwitch
+                text: qsTr("Fixed space font: use system font")
+                Layout.fillWidth: true
+                checked: true
+                onCheckedChanged: fontSettings.setFontFixed()
+            }
+            WComboBox {
+                id: fontFixedBox
+                sizeToContents: true
+                enabled: !fontFixedSystemSwitch.checked
+                model: fontSettings.fontList
+                onCurrentIndexChanged: {
+                    if (fontSettings.fontFixedName === undefined ||
+                        fontSettings.fontFixedName === "" ||
+                        fontSettings.fontList.indexOf(fontSettings.fontFixedName) === -1)
+                    {
+                        fontSettings.fontFixedName = guiHelper.systemFontFixed
+                        currentIndex = fontSettings.fontList.indexOf(fontSettings.fontFixedName)
+                    }
+                    else
+                    {
+                        fontSettings.fontFixedName = model[currentIndex]
+                    }
+                    fontSettings.setFontFixed()
+                }
+                Component.onCompleted: {
+                    currentIndex = fontSettings.fontList.indexOf(fontSettings.fontFixedName)
+                    fontSettings.setFontFixed()
+                }
+            }
+            function setFontFixed() {
+                if (fontFixedSystemSwitch.checked) {
+                    TextStyle.textFontFixed = guiHelper.systemFontFixed
+                } else {
+                    TextStyle.textFontFixed = fontSettings.fontFixedName
+                }
+                console.debug("Fixed font set to: " + TextStyle.textFontFixed)
             }
         }
     }

--- a/src/welle-gui/QML/texts/TextStyle.qml
+++ b/src/welle-gui/QML/texts/TextStyle.qml
@@ -13,8 +13,9 @@ QtObject {
     property int textStation: Units.em(0.9)
 
     // Text font and color
-    property string textFont: "Arial"
-    //property string textFont: "Times"
+    property string textFont: "sans serif"
+    property string textFontFixed: "monospace"
     //property color textColor: "white"
     property color textColor: "black"
+
 }

--- a/src/welle-gui/gui_helper.cpp
+++ b/src/welle-gui/gui_helper.cpp
@@ -62,6 +62,9 @@ CGUIHelper::CGUIHelper(CRadioController *RadioController, QObject *parent)
     connect(RadioController, &CRadioController::showErrorMessage, this, &CGUIHelper::showErrorMessage);
     connect(RadioController, &CRadioController::showInfoMessage, this, &CGUIHelper::showInfoMessage);
 
+    systemFontFixed = QFontDatabase::systemFont(QFontDatabase::FixedFont).family();
+    systemFontGeneral = QFontDatabase::systemFont(QFontDatabase::GeneralFont).family();
+
 #ifndef QT_NO_SYSTEMTRAYICON
     minimizeAction = new QAction(tr("Mi&nimize"), this);
     connect(minimizeAction, SIGNAL(triggered()), this, SIGNAL(minimizeWindow()));

--- a/src/welle-gui/gui_helper.h
+++ b/src/welle-gui/gui_helper.h
@@ -123,6 +123,8 @@ class CGUIHelper : public QObject
     Q_PROPERTY(QVariant licenses READ licenses CONSTANT)
     Q_PROPERTY(StyleModel* qQStyleComboModel READ qQStyleComboModel CONSTANT)
     Q_PROPERTY(QString getQQStyle READ getQQStyle CONSTANT)
+    Q_PROPERTY(QString systemFontGeneral MEMBER systemFontGeneral CONSTANT)
+    Q_PROPERTY(QString systemFontFixed MEMBER systemFontFixed CONSTANT)
 
 public:
     Q_INVOKABLE void updateTranslator(QString Language, QObject *obj);
@@ -191,6 +193,9 @@ private:
 
     const QVariantMap licenses();
     const QByteArray getFileContent(QString filepath);
+
+    QString systemFontGeneral;
+    QString systemFontFixed;
 
     // Qt Quick Style Management methods & members
     QSettings settings;


### PR DESCRIPTION
* use system default fonts by default
* the user can choose another font through the settings

Among other reasons, this can be of interest for example for **accessibility**

![welle-fonts](https://user-images.githubusercontent.com/46226844/79593261-7f4a7280-80db-11ea-9a27-92c297ff0c2b.png)
