### PR TITLE
Manage play/stop in case of rtl-sdr unplug

### DIFF
--- a/src/backend/ofdm-processor.cpp
+++ b/src/backend/ofdm-processor.cpp
@@ -494,6 +494,7 @@ SyncOnPhase:
     }
     catch (const InputFailure&) {
         std::clog << "OFDM-processor: input not ok, closing down" << std::endl;
+        running = false; //Needed before onInputFailure, because subsequent calls will call OFDMProcessor::stop()
         radioInterface.onInputFailure();
     }
     running = false;
@@ -501,9 +502,11 @@ SyncOnPhase:
 
 void OFDMProcessor::stop()
 {
-    running = false;
-    if (threadHandle.joinable()) {
-        threadHandle.join();
+    if (running) {
+        running = false;
+        if (threadHandle.joinable()) {
+            threadHandle.join();
+        }
     }
 }
 

--- a/src/input/rtl_sdr.h
+++ b/src/input/rtl_sdr.h
@@ -100,6 +100,7 @@ private:
     int32_t sampleCounter = 0;
 
     static void rtlsdr_read_callback(uint8_t* buf, uint32_t len, void *ctx);
+    void open_device();
 };
 
 

--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -1058,3 +1058,8 @@ void CRadioController::onPADLengthError(size_t announced_xpad_len, size_t xpad_l
 {
     qDebug() << "X-PAD length mismatch, expected:" << announced_xpad_len << " effective:" << xpad_len;
 }
+
+void CRadioController::onInputFailure()
+{
+    stop();
+}

--- a/src/welle-gui/radio_controller.h
+++ b/src/welle-gui/radio_controller.h
@@ -152,6 +152,7 @@ public:
     virtual void onNewNullSymbol(std::vector<DSPCOMPLEX>&& data) override;
     virtual void onTIIMeasurement(tii_measurement_t&& m) override;
     virtual void onMessage(message_level_t level, const std::string& text, const std::string& text2 = std::string()) override;
+    virtual void onInputFailure(void) override;
 
 private:
     void initialise(void);


### PR DESCRIPTION
- If the device is unplugged, welle-io's playback state is set to "stop"
- If the device is plugged in again, clicking on 'play' reloads the device and starts playing
(before, welle-io was blocked in "rtl-sdr is unplugged" state, and only way to get it back playing was to restart the app, or trigger a device change in the parameters)

**Needs #532**