### PR TITLE
macOS DMG image build

### DIFF
--- a/.travis-bintray-deploy.json.template
+++ b/.travis-bintray-deploy.json.template
@@ -8,7 +8,7 @@
     "name": "${VERSION}"
   },
   "files": [
-    {"includePattern": ".(.*welle-io.*.AppImage)", "uploadPattern": "$1"},
+    {"includePattern": ".(.*welle-io.*.(AppImage|dmg))", "uploadPattern": "$1"},
     {"includePattern": ".(.*welle-io-cli.*.AppImage)", "uploadPattern": "$1"}
   ],
   "publish": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ jobs:
         - find build
         - cd build/src/welle-gui
         - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
-        - create-dmg --app-drop-link 350 0 --volname welle.io "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg welle-io.app
+        - create-dmg --app-drop-link 350 0 --volname welle.io --skip-jenkins "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg welle-io.app
 
         # Upload DMG
         - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg https://transfer.sh/welle-io.dmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ jobs:
         - brew update
       install:
         - brew install fftw faad2 lame mpg123 soapysdr soapyuhd
+        - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,10 +119,10 @@ jobs:
         - cd build/src/welle-gui
         - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
         - cd ../../..
-        - mv build/src/welle-gui/welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg
+        - mv build/src/welle-gui/welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
 
-        # Upload DMG
-        - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg https://transfer.sh/welle-io.dmg
+        # Prepare bintray deploy
+        - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,14 +103,15 @@ jobs:
         - brew tap pothosware/homebrew-pothos
         - brew update
       install:
-        - brew install fftw faad2 lame mpg123 soapysdr soapyuhd
+        - brew install create-dmg fftw faad2 lame mpg123 soapysdr soapyuhd
         - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
         - export LIBRARY_PATH=/usr/local/lib
       after_success:
         # Prepare welle.io DMG
         - find build
         - cd build/src/welle-gui
-        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
+        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
+        - create-dmg --app-drop-link 350 0 --volname welle.io "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg welle-io.app
 
         # Upload DMG
         - curl --upload-file welle-io.dmg https://transfer.sh/welle-io.dmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cd airspyone_host-master/
   - mkdir build
   - cd build
-  - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake ../ -DINSTALL_UDEV_RULES=ON
   - make -j 4
   - sudo make install
   - cd ../..

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
         - brew update
 
       install:
-        - brew install create-dmg fftw faad2 lame mpg123 soapysdr soapyuhd
+        - brew install fftw faad2 lame mpg123 soapysdr soapyuhd
         - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
         - export LIBRARY_PATH=/usr/local/lib
 
@@ -117,10 +117,9 @@ jobs:
         # Prepare welle.io DMG
         - find build
         - cd build/src/welle-gui
-        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
-        - create-dmg --app-drop-link 350 0 --volname welle.io --skip-jenkins "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg welle-io.app
+        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -DMG
         - cd ../../..
-        - mv build/src/welle-gui/"$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg
+        - mv build/src/welle-gui/welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg
 
         # Upload DMG
         - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg https://transfer.sh/welle-io.dmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
       after_success:
         # Create welle.io DMG
         - find build/
-        - macdeployqt build/src/welle-gui/welle-io.app -dmg
+        - /usr/local/opt/qt/bin/macdeployqt build/src/welle-gui/welle-io.app -dmg
 
         # Upload DMG
         curl --upload-file build/src/welle-gui/welle-io.dmg https://transfer.sh/welle-io.dmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ jobs:
         - create-dmg --app-drop-link 350 0 --volname welle.io "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg welle-io.app
 
         # Upload DMG
-        - curl --upload-file welle-io.dmg https://transfer.sh/welle-io.dmg
+        - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg https://transfer.sh/welle-io.dmg
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - linux
+  - osx
 dist: bionic
 language: cpp
 compiler: gcc
@@ -21,7 +22,7 @@ script:
   - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j 4
   - sudo make install
-  - sudo ldconfig
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; sudo ldconfig; fi
   - cd ../..
   
   # Compile librtlsdr
@@ -32,7 +33,7 @@ script:
   - cmake ../  -DDETACH_KERNEL_DRIVER=ON
   - make -j 4
   - sudo make install
-  - sudo ldconfig
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; sudo ldconfig; fi
   - cd ../..
   
   # Compile welle.io
@@ -99,6 +100,12 @@ jobs:
         
         # Prepare bintray deploy
         - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
+    - os: osx
+      before_install:
+        - brew tap pothosware/homebrew-pothos
+        - brew update
+      install:
+        - brew install qt fftw faad2 mpg123 soapysdr soapyuhd libusb
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ jobs:
         # Prepare welle.io DMG
         - find build
         - cd build/src/welle-gui
-        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -DMG
+        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
         - cd ../../..
         - mv build/src/welle-gui/welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,16 +48,19 @@ script:
 jobs:
   include:
     - os: linux
+
       before_install:
         # QT
         - sudo add-apt-repository ppa:beineri/opt-qt-5.14.0-bionic -y
         # SoapySDR
         - sudo add-apt-repository ppa:myriadrf/drivers -y
         - sudo apt-get update -qq
+
       install:
         - sudo apt-get -y install gcc g++
         - sudo apt-get -y install libusb-1.0-0-dev pkg-config libmp3lame-dev libmpg123-dev qt514base qt514declarative qt514quickcontrols qt514quickcontrols2 qt514charts-no-lgpl qt514graphicaleffects qt514multimedia libpulse0 libfaad-dev libfftw3-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev
         - source /opt/qt514/bin/qt514-env.sh
+
       after_success:
         - sudo ldconfig
 
@@ -97,15 +100,19 @@ jobs:
         
         # Prepare bintray deploy
         - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
+
     - os: osx
       osx_image: xcode11.3
+
       before_install:
         - brew tap pothosware/homebrew-pothos
         - brew update
+
       install:
         - brew install create-dmg fftw faad2 lame mpg123 soapysdr soapyuhd
         - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
         - export LIBRARY_PATH=/usr/local/lib
+
       after_success:
         # Prepare welle.io DMG
         - find build
@@ -118,7 +125,7 @@ jobs:
 
 deploy:
   on:
-   branch: next
+    branch: next
   provider: bintray
   file: "travis-bintray-deploy.json"
   user: "albrechtl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ jobs:
         - sudo apt-get -y install libusb-1.0-0-dev pkg-config libmp3lame-dev libmpg123-dev qt514base qt514declarative qt514quickcontrols qt514quickcontrols2 qt514charts-no-lgpl qt514graphicaleffects qt514multimedia libpulse0 libfaad-dev libfftw3-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev
         - source /opt/qt514/bin/qt514-env.sh
       after_success:
+        - sudo ldconfig
+
         # Get linuxdeploy
         - sudo wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -P /usr/local/bin
         - sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
   - cmake ../ -DINSTALL_UDEV_RULES=ON -DCMAKE_INSTALL_PREFIX=/usr
   - make -j 4
   - sudo make install
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; sudo ldconfig; fi
   - cd ../..
   
   # Compile librtlsdr
@@ -33,7 +32,6 @@ script:
   - cmake ../  -DDETACH_KERNEL_DRIVER=ON
   - make -j 4
   - sudo make install
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; sudo ldconfig; fi
   - cd ../..
   
   # Compile welle.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,7 @@ jobs:
         # Prepare bintray deploy
         - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
     - os: osx
+      osx_image: xcode11.3
       before_install:
         - brew tap pothosware/homebrew-pothos
         - brew update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os:
+  - linux
 dist: bionic
 language: cpp
 compiler: gcc
@@ -7,18 +9,6 @@ env:
   # "BINTRAY_KEY=<secure>"
   - secure: "AjycfSfIztFeat6AO3SETSFW9Xd0AUt17hg87sEo8pSPO3SILq6bKS5Pfe4Bdo3Za32BvGzeJaOZ9EEVtzweuYJwsBejVfk2lxiBH5RKoBVrHpJLXDNj7MUt2ezb734bjFFt3+lMG84vSCqioNMcYwlHcqCChiTT529NZhaGMsDFzF5NimJZl0LGcEQlaTxTfeCKwSk+apHw5rQes2I2Jf9icweUGe/VOOVmYjDTiPWKcBEwBvfV5vabr5btCgUY8zK5451x/35API2Hbq7o0hNxqvwQUFI54jZwqfR4DOA1V/Nk7rdc34Fe+xgKSoBmHC0RgCIbXw1erEkn31Y0+tLBVxa971FB+y7L+5ZEaqw9UolT0PM5LHZmWUA60A5JlvsFOr0urid8lk0g5mdGF4aHEy2O5rDOMbwE11MpTEkDDbgE6uSD0/aubTJYPu24yMlBrP1lz10Sltg+YLi5hshhzRmd4iWTKuEy4jly1SdOKjjdbLCzlAnsF9Ta0a/lfumOd2lmELhYKhFLuVTCWZFvjpJyziCIFLVs4refDbDrsdfE+CaJedP/uBDGoBp4Hg6aug+66zKPybVzODqR2uIa3I7ACM3l/GdJcGg+1AH1T/ievq4rQ52T3MspevFxQmevuA9vvgOVko79PDrW1xbp+oQPTk0/pODNjVvrZFk="
 
-before_install:
-    # QT
-    - sudo add-apt-repository ppa:beineri/opt-qt-5.14.0-bionic -y
-    # SoapySDR
-    - sudo add-apt-repository ppa:myriadrf/drivers -y
-    - sudo apt-get update -qq
-
-install:
-    - sudo apt-get -y install gcc g++
-    - sudo apt-get -y install libusb-1.0-0-dev pkg-config libmp3lame-dev libmpg123-dev qt514base qt514declarative qt514quickcontrols qt514quickcontrols2 qt514charts-no-lgpl qt514graphicaleffects qt514multimedia libpulse0 libfaad-dev libfftw3-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev
-    - source /opt/qt514/bin/qt514-env.sh
-    
 script:
   - DATE=`date +%Y%m%d`
   - GIT_HASH=`git rev-parse --short HEAD`
@@ -59,44 +49,57 @@ script:
   - cmake ../
   - make -j4
   - cd ..
-  
-after_success:
-  # Get linuxdeploy
-  - sudo wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -P /usr/local/bin
-  - sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
-  - sudo wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -P /usr/local/bin
-  - sudo chmod +x /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage
-  
-  # Prepare welle.io AppImage
-  - find build/
-  - mkdir -p ./appdir/usr/share/applications
-  - cp welle-io.desktop ./appdir/usr/share/applications
-  - mkdir -p ./appdir/usr/bin
-  - cp build/src/welle-gui/welle-io ./appdir/usr/bin
-  - mkdir -p ./appdir/usr/lib
-  - mkdir -p ./appdir/usr/share/icons/hicolor/512x512/apps/
-  - cp src/welle-gui/icons/icon.png appdir/usr/share/icons/hicolor/512x512/apps/welle-io.png
-  
-  # Create welle.io AppImage
-  - QML_SOURCES_PATHS=. linuxdeploy-x86_64.AppImage --appdir ./appdir --plugin qt --output appimage
-  - mv welle.io-"$GIT_HASH"-x86_64.AppImage "$DATE"_"$GIT_HASH"_Linux_welle-io-x86_64.AppImage
 
-  # Prepare welle-cli AppImage
-  - find build-cli/
-  - mkdir -p ./appdir-cli/usr/share/applications
-  - cp welle-cli.desktop ./appdir-cli/usr/share/applications
-  - mkdir -p ./appdir-cli/usr/bin
-  - cp build-cli/welle-cli ./appdir-cli/usr/bin
-  - mkdir -p ./appdir-cli/usr/lib
-  - mkdir -p ./appdir-cli/usr/share/icons/hicolor/512x512/apps/
-  - cp src/welle-gui/icons/icon.png appdir-cli/usr/share/icons/hicolor/512x512/apps/welle-io.png
-  
-  # Create welle-cli AppImage
-  - linuxdeploy-x86_64.AppImage --appdir ./appdir-cli --output appimage
-  - mv welle.io-cli-"$GIT_HASH"-x86_64.AppImage "$DATE"_"$GIT_HASH"_Linux_welle-io-cli-x86_64.AppImage
-  
-  # Prepare bintray deploy
-  - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
+jobs:
+  include:
+    - os: linux
+      before_install:
+        # QT
+        - sudo add-apt-repository ppa:beineri/opt-qt-5.14.0-bionic -y
+        # SoapySDR
+        - sudo add-apt-repository ppa:myriadrf/drivers -y
+        - sudo apt-get update -qq
+      install:
+        - sudo apt-get -y install gcc g++
+        - sudo apt-get -y install libusb-1.0-0-dev pkg-config libmp3lame-dev libmpg123-dev qt514base qt514declarative qt514quickcontrols qt514quickcontrols2 qt514charts-no-lgpl qt514graphicaleffects qt514multimedia libpulse0 libfaad-dev libfftw3-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev
+        - source /opt/qt514/bin/qt514-env.sh
+      after_success:
+        # Get linuxdeploy
+        - sudo wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -P /usr/local/bin
+        - sudo chmod +x /usr/local/bin/linuxdeploy-x86_64.AppImage
+        - sudo wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage -P /usr/local/bin
+        - sudo chmod +x /usr/local/bin/linuxdeploy-plugin-qt-x86_64.AppImage
+        
+        # Prepare welle.io AppImage
+        - find build/
+        - mkdir -p ./appdir/usr/share/applications
+        - cp welle-io.desktop ./appdir/usr/share/applications
+        - mkdir -p ./appdir/usr/bin
+        - cp build/src/welle-gui/welle-io ./appdir/usr/bin
+        - mkdir -p ./appdir/usr/lib
+        - mkdir -p ./appdir/usr/share/icons/hicolor/512x512/apps/
+        - cp src/welle-gui/icons/icon.png appdir/usr/share/icons/hicolor/512x512/apps/welle-io.png
+        
+        # Create welle.io AppImage
+        - QML_SOURCES_PATHS=. linuxdeploy-x86_64.AppImage --appdir ./appdir --plugin qt --output appimage
+        - mv welle.io-"$GIT_HASH"-x86_64.AppImage "$DATE"_"$GIT_HASH"_Linux_welle-io-x86_64.AppImage
+
+        # Prepare welle-cli AppImage
+        - find build-cli/
+        - mkdir -p ./appdir-cli/usr/share/applications
+        - cp welle-cli.desktop ./appdir-cli/usr/share/applications
+        - mkdir -p ./appdir-cli/usr/bin
+        - cp build-cli/welle-cli ./appdir-cli/usr/bin
+        - mkdir -p ./appdir-cli/usr/lib
+        - mkdir -p ./appdir-cli/usr/share/icons/hicolor/512x512/apps/
+        - cp src/welle-gui/icons/icon.png appdir-cli/usr/share/icons/hicolor/512x512/apps/welle-io.png
+        
+        # Create welle-cli AppImage
+        - linuxdeploy-x86_64.AppImage --appdir ./appdir-cli --output appimage
+        - mv welle.io-cli-"$GIT_HASH"-x86_64.AppImage "$DATE"_"$GIT_HASH"_Linux_welle-io-cli-x86_64.AppImage
+        
+        # Prepare bintray deploy
+        - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ jobs:
         - export LIBRARY_PATH=/usr/local/lib
       after_success:
         # Prepare welle.io DMG
-        - find build/
+        - find build
         - cd build/src/welle-gui
         - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
         - /usr/local/opt/qt/bin/macdeployqt build/src/welle-gui/welle-io.app -dmg
 
         # Upload DMG
-        curl --upload-file build/src/welle-gui/welle-io.dmg https://transfer.sh/welle-io.dmg
+        - curl --upload-file build/src/welle-gui/welle-io.dmg https://transfer.sh/welle-io.dmg
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
 dist: bionic
 language: cpp
 compiler: gcc
-sudo: require
 
 env:
   # "BINTRAY_KEY=<secure>"

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ jobs:
       install:
         - brew install fftw faad2 lame mpg123 soapysdr soapyuhd
         - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
+        - export LIBRARY_PATH=/usr/local/lib
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   # Compile welle-cli
   - mkdir build-cli
   - cd build-cli
-  - cmake ../
+  - cmake ../  -DBUILD_WELLE_IO=OFF -DAIRSPY=TRUE -DRTLSDR=TRUE -DSOAPYSDR=TRUE
   - make -j4
   - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-os:
-  - linux
-  - osx
 dist: bionic
 language: cpp
 compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,9 +119,11 @@ jobs:
         - cd build/src/welle-gui
         - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
         - create-dmg --app-drop-link 350 0 --volname welle.io --skip-jenkins "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg welle-io.app
+        - cd ../../..
+        - mv build/src/welle-gui/"$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg
 
         # Upload DMG
-        - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg https://transfer.sh/welle-io.dmg
+        - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle.io.dmg https://transfer.sh/welle-io.dmg
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,13 @@ jobs:
         - brew install fftw faad2 lame mpg123 soapysdr soapyuhd
         - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
         - export LIBRARY_PATH=/usr/local/lib
+      after_success:
+        # Create welle.io DMG
+        - find build/
+        - macdeployqt build/src/welle-gui/welle-io.app -dmg
+
+        # Upload DMG
+        curl --upload-file build/src/welle-gui/welle-io.dmg https://transfer.sh/welle-io.dmg
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
         - brew tap pothosware/homebrew-pothos
         - brew update
       install:
-        - brew install qt fftw faad2 mpg123 soapysdr soapyuhd libusb
+        - brew install fftw faad2 mpg123 soapysdr soapyuhd
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ jobs:
         - brew tap pothosware/homebrew-pothos
         - brew update
       install:
-        - brew install fftw faad2 mpg123 soapysdr soapyuhd
+        - brew install fftw faad2 lame mpg123 soapysdr soapyuhd
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,12 +107,13 @@ jobs:
         - ln -s /usr/local/opt/qt/bin/qmake /usr/local/bin/qmake
         - export LIBRARY_PATH=/usr/local/lib
       after_success:
-        # Create welle.io DMG
+        # Prepare welle.io DMG
         - find build/
-        - /usr/local/opt/qt/bin/macdeployqt build/src/welle-gui/welle-io.app -dmg
+        - cd build/src/welle-gui
+        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
 
         # Upload DMG
-        - curl --upload-file build/src/welle-gui/welle-io.dmg https://transfer.sh/welle-io.dmg
+        - curl --upload-file welle-io.dmg https://transfer.sh/welle-io.dmg
 
 deploy:
   on:


### PR DESCRIPTION
This pull request adds a macOS build to Travis CI, which creates a DMG image for easy deployment and installation. This resolves #442.

Due to the licensing concerns raised in the issue this builds both the GUI and CLI, but packages and deploys only the GUI.

This also corrects a couple other minor issues with the Travis builds:

- Removes the deprecated sudo tag
- Fixes the CLI CMake build to build only the CLI, previously this was running a duplicate build of the GUI as well as the CLI

Bintray deployment has not been tested but I think it should work. Let me know if it doesn't.