### PR TITLE
Fix macOS DMG filename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ jobs:
         - cd build/src/welle-gui
         - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
         - cd ../../..
-        - mv build/src/welle-gui/welle.io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
+        - mv build/src/welle-gui/welle-io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
 
         # Prepare bintray deploy
         - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json


### PR DESCRIPTION
Following on from #556, this fixes the DMG rename so that it now has a filename with the format `<build date>_<git hash>_MacOS_welle-io.dmg`.