### PR TITLE
DMG build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ jobs:
         # Prepare welle.io DMG
         - find build
         - cd build/src/welle-gui
-        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
+        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -libpath=/usr/local/lib -dmg
         - cd ../../..
         - mv build/src/welle-gui/welle-io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,9 @@ jobs:
         - export LIBRARY_PATH=/usr/local/lib
 
       after_success:
+        # Get macdeployqtfix
+        - curl -O https://raw.githubusercontent.com/arl/macdeployqtfix/master/macdeployqtfix.py
+
         # Prepare welle.io app
         - find build
         - mkdir appdir
@@ -121,6 +124,7 @@ jobs:
         - /usr/local/opt/qt/bin/macdeployqt appdir/welle.io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
         - cp /usr/local/lib/librtlsdr.0.dylib appdir/welle.io.app/Contents/Frameworks/librtlsdr.0.dylib
         - install_name_tool -change @rpath/librtlsdr.0.dylib @executable_path/../Frameworks/librtlsdr.0.dylib appdir/welle.io.app/Contents/MacOS/welle-io
+        - python macdeployqtfix.py appdir/welle.io.app/Contents/MacOS/welle.io /usr/local/opt/qt
 
         # Add shortcut to Applications
         - ln -s /Applications appdir/Applications

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,8 @@ jobs:
         - mkdir appdir
         - cp -R build/src/welle-gui/welle-io.app appdir/welle.io.app
         - /usr/local/opt/qt/bin/macdeployqt appdir/welle.io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
+        - cp /usr/local/lib/librtlsdr.0.dylib appdir/welle.io.app/Contents/Frameworks/librtlsdr.0.dylib
+        - install_name_tool -change @rpath/librtlsdr.0.dylib @executable_path/../Frameworks/librtlsdr.0.dylib appdir/welle.io.app/Contents/MacOS/welle-io
 
         # Add shortcut to Applications
         - ln -s /Applications appdir/Applications

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ jobs:
         # Prepare welle.io DMG
         - find build
         - cd build/src/welle-gui
-        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -libpath=/usr/local/lib -dmg
+        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
         - cd ../../..
         - mv build/src/welle-gui/welle-io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,12 +114,16 @@ jobs:
         - export LIBRARY_PATH=/usr/local/lib
 
       after_success:
-        # Prepare welle.io DMG
+        # Prepare welle.io app
         - find build
-        - cd build/src/welle-gui
-        - /usr/local/opt/qt/bin/macdeployqt welle-io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML -dmg
-        - cd ../../..
-        - mv build/src/welle-gui/welle-io.dmg "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
+        - mkdir appdir
+        - cp -R build/src/welle-gui/welle-io.app appdir/welle.io.app
+        - /usr/local/opt/qt/bin/macdeployqt appdir/welle.io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
+
+        # Build DMG
+        - hdiutil create welle-io.dmg -ov -volname "Install welle.io" -fs HFS+ -srcfolder appdir
+        - hdiutil convert welle-io.dmg -format UDZO -o "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
+        - rm welle-io.dmg
 
         # Prepare bintray deploy
         - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,6 @@ jobs:
         # Create welle-cli AppImage
         - linuxdeploy-x86_64.AppImage --appdir ./appdir-cli --output appimage
         - mv welle.io-cli-"$GIT_HASH"-x86_64.AppImage "$DATE"_"$GIT_HASH"_Linux_welle-io-cli-x86_64.AppImage
-        
-        # Prepare bintray deploy
-        - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
 
     - os: osx
       osx_image: xcode11.3
@@ -134,11 +131,12 @@ jobs:
         - hdiutil convert welle-io.dmg -format UDZO -o "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
         - rm welle-io.dmg
 
-        # Prepare bintray deploy
-        - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
-
         # Upload DMG
         - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg https://transfer.sh/welle-io.dmg
+
+before_deploy:
+  # Prepare bintray deploy
+  - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
 
 deploy:
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,9 +131,6 @@ jobs:
         - hdiutil convert welle-io.dmg -format UDZO -o "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg
         - rm welle-io.dmg
 
-        # Upload DMG
-        - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg https://transfer.sh/welle-io.dmg
-
 before_deploy:
   # Prepare bintray deploy
   - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,9 @@ jobs:
         # Prepare bintray deploy
         - sed -e "s/\${VERSION}/"$DATE"_"$GIT_HASH"/" .travis-bintray-deploy.json.template >travis-bintray-deploy.json
 
+        # Upload DMG
+        - curl --upload-file "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg https://transfer.sh/welle-io.dmg
+
 deploy:
   on:
     branch: next

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,9 @@ jobs:
         - cp -R build/src/welle-gui/welle-io.app appdir/welle.io.app
         - /usr/local/opt/qt/bin/macdeployqt appdir/welle.io.app -qmldir=$TRAVIS_BUILD_DIR/src/welle-gui/QML
 
+        # Add shortcut to Applications
+        - ln -s /Applications appdir/Applications
+
         # Build DMG
         - hdiutil create welle-io.dmg -ov -volname "Install welle.io" -fs HFS+ -srcfolder appdir
         - hdiutil convert welle-io.dmg -format UDZO -o "$DATE"_"$GIT_HASH"_MacOS_welle-io.dmg


### PR DESCRIPTION
This makes a few small improvements to the macOS DMG build:

- Manually bundles librtlsdr. This fixes #564.
- Checks the binaries link to the correct paths for the libraries bundled with the app, and fixes them where they don't.
- Adds a shortcut to the Applications folder in the DMG, as is standard and expected by users.
- Tweaks the application name so it appears as 'welle.io' instead of 'welle-io'.
- Moves bintray preparation from the after_success build step to before_deploy build step. This removes duplication.