### PR TITLE
(#601) FreeBSD Installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Download
     * `sudo port install welle.io +cli` (if you wish to install also welle-cli)
 * welle.io for **FreeBSD**
   * Building from sources (requires ports tree to be checked out at `/usr/ports/`)
-    ```console
+    ```
     # cd /usr/ports/audio/welle.io/
     # make install clean
     ```
@@ -209,9 +209,9 @@ This section describes how to build welle.io from sources on FreeBSD 12.2 and 13
 
 1. You will need the following dependencies, either built from the
    ports or installed as a binary package. You may also build them
-   yourself:
+   yourself.
 
-   ```console
+   ```
    # pkg install alsa-lib faad lame mpg123 pkgconf cmake qt5-charts \
      qt5-core qt5-declarative qt5-gui qt5-multimedia qt5-network \
      qt5-quickcontrols2 qt5-widgets qt5-buildtools qt5-qmake \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Download
   * [through **MacPorts port**](https://ports.macports.org/port/welle.io/summary) (requires [MacPorts](https://www.macports.org/)) 
     * `sudo port install welle.io`
     * `sudo port install welle.io +cli` (if you wish to install also welle-cli)
+* welle.io for **FreeBSD**
+  * Building from sources (requires ports tree to be checked out at `/usr/ports/`)
+    ```console
+    # cd /usr/ports/audio/welle.io/
+    # make install clean
+    ```
+  * Installing the binary package
+    * `pkg install welle.io`
 
 If you discovered an issue please open a new [issue](https://github.com/AlbrechtL/welle.io/issues).
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,26 @@ You need to install the dependencies with MacPorts first, assuming you have [Mac
 4. Make sure in Qt Creator, "Projects, Build&Run, Run" that the checkbox "Add build library path to DYLD..." is off.
 5. Build and run.
 
-CMake instead of Qt Creator (Windows, Linux, macOS)
+FreeBSD
+---
+This section describes how to build welle.io from sources on FreeBSD 12.2 and 13.0.
+
+1. You will need the following dependencies, either built from the
+   ports or installed as a binary package. You may also build them
+   yourself:
+
+   ```console
+   # pkg install alsa-lib faad lame mpg123 pkgconf cmake qt5-charts \
+     qt5-core qt5-declarative qt5-gui qt5-multimedia qt5-network \
+     qt5-quickcontrols2 qt5-widgets qt5-buildtools qt5-qmake \
+     rtl-sdr fftw3-float fftw3
+   ```
+   For SoapySDR support, you will also need `soapysdr`. For AirSpy support, you will need `airspy`.
+
+2. Now follow the build instructions for CMake as indicated below.
+
+
+CMake instead of Qt Creator (Windows, Linux, macOS, FreeBSD)
 ---
 
 As an alternative to Qt Creator, CMake can be used for building welle.io after installing dependencies and cloning the repository. On Linux, you can also use CMake to build [**welle-cli**](#welle-cli), the command-line backend testing tool that does not require Qt.


### PR DESCRIPTION
As discussed in #601 , I added the instruction for installing the `welle.io` package from the ports (both building the package from sources or installing the prebuilt binary using pkg).

The CMake aproach is a bit less painful, so I added instructions for that (refer to the Ports Makefile, this is what I did there as well).

Please let me know if you have issues with the PR or if I should squash the commits.