### PR TITLE
gui: Add hotkey / keyboard shortcuts support:

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ Parameter | Description
 --dump-file | Records DAB frames (*.mp2) or DAB+ superframes with RS coding (*.dab). This file can be used to analyse X-PAD data with XPADxpert (https://www.basicmaster.de/xpadxpert).
 --log-file | Log file name. Redirects all log output texts to a file.
 
+Keyboard shortcuts & hotkeys
+
+Keystroke | Action
+------ | ----------
+F1-F12, 1-9, 0, Ctrl+1-9, Ctrl+0 | Play the station no. 'x' in the stations list: <br />`1` for station no. `1`, <br />`0` for station no. `10`, <br />`Ctrl+1` for station no. `11`...
+S, Media Play, Media Stop, Media Pause, Media Play/Pause | Start playback/Stop
+N, Media next | play next station in list
+P, Media Previous | play previous station
+M, Volume Mute | mute/unmute
+Ctrl+Up, Volume Up | Volume Up
+Ctrl+Down, Volume Down | Volume Down
+
 Supported Hardware
 ====================
 The following SDR devices are supported

--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -190,21 +190,30 @@ ApplicationWindow {
                     hoverEnabled: true
                     onClicked: {
                         if (radioController.isPlaying) {
-                            radioController.stop();
+                            startStopIcon.stop()
                         } else {
-                            var channel = radioController.lastChannel[1]
-                            var sidHex = radioController.lastChannel[0]
-                            var sidDec = parseInt(sidHex,16);
-                            var stationName = stationList.getStationName(sidDec, channel)
-                            //console.debug("stationName: " + stationName + " channel: " + channel + " sidHex: "+ sidHex)
-                            if (!channel || !sidHex || !stationName) {
-                                infoMessagePopup.text = qsTr("Last played station not found.\nSelect a station to start playback.");
-                                infoMessagePopup.open();
-                            } else {
-                                radioController.play(channel, stationName, sidDec)
-                            }
+                            startStopIcon.play()
                         }
                     }
+                }
+
+                Shortcut {
+                    context: Qt.ApplicationShortcut
+                    autoRepeat: false
+                    sequences: ["Media Pause", "Toggle Media Play/Pause", "S"]
+                    onActivated: startStopIconMouseArea.clicked(0)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut
+                    autoRepeat: false
+                    sequences: ["Media Stop"]
+                    onActivated: if (radioController.isPlaying) startStopIcon.stop()
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut
+                    autoRepeat: false
+                    sequences: ["Media Play"]
+                    onActivated: if (!radioController.isPlaying) startStopIcon.play()
                 }
 
                 Connections {
@@ -220,6 +229,16 @@ ApplicationWindow {
                     } else {
                         startStopIcon.source = "qrc:/icons/welle_io_icons/20x20/play.png"
                     }
+                }
+
+                function play() {
+                    var channel = radioController.lastChannel[1]
+                    var sidHex = radioController.lastChannel[0]
+                    stationList.play(channel, sidHex)
+                }
+
+                function stop() {
+                    radioController.stop();
                 }
             }
 
@@ -371,6 +390,36 @@ ApplicationWindow {
                                 text: Math.round(volumeSlider.value*100) + "%"
 
                                 Accessible.description: qsTr("Volume set to %1").arg(text)
+                            }
+
+                            Shortcut {
+                                context: Qt.ApplicationShortcut
+                                autoRepeat: true
+                                sequences: ["Ctrl+Up", "Volume Up"]
+                                onActivated: {
+                                    volumeSlider.visible = true
+                                    volumeSlider.value = volumeSlider.value + volumeSlider.stepSize
+                                }
+                            }
+
+                            Shortcut {
+                                context: Qt.ApplicationShortcut
+                                autoRepeat: true
+                                sequences: ["Ctrl+Down", "Volume Down"]
+                                onActivated: {
+                                    volumeSlider.visible = true
+                                    volumeSlider.value = volumeSlider.value - volumeSlider.stepSize
+                                }
+                            }
+
+                            Shortcut {
+                                context: Qt.ApplicationShortcut
+                                autoRepeat: false
+                                sequences: ["m", "Volume Mute"]
+                                onActivated: {
+                                    volumeSlider.visible = true
+                                    volumeSlider.value = !(volumeSlider.value)
+                                }
                             }
                         }
                     }
@@ -566,6 +615,109 @@ ApplicationWindow {
                 }
 
                 ScrollIndicator.vertical: ScrollIndicator { }
+
+                Shortcut {
+                    context: Qt.ApplicationShortcut
+                    autoRepeat: false
+                    sequences: ["n", "Media Next"]
+                    onActivated: {
+                        var channel = radioController.lastChannel[1]
+                        var sidHex = radioController.lastChannel[0]
+                        var index = stationChannelView.model.getIndexNext(parseInt(sidHex,16), channel)
+                        stationChannelView.model.playAtIndex(index)
+                    }
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut
+                    autoRepeat: false
+                    sequences: ["p", "Media Previous"]
+                    onActivated: {
+                        var channel = radioController.lastChannel[1]
+                        var sidHex = radioController.lastChannel[0]
+                        var index = stationChannelView.model.getIndexPrevious(parseInt(sidHex,16), channel)
+                        stationChannelView.model.playAtIndex(index)
+                    }
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F1", "1"]
+                    onActivated: stationChannelView.model.playAtIndex(0)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F2", "2"]
+                    onActivated: stationChannelView.model.playAtIndex(1)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F3", "3"]
+                    onActivated: stationChannelView.model.playAtIndex(2)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F4", "4"]
+                    onActivated: stationChannelView.model.playAtIndex(3)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F5", "5"]
+                    onActivated: stationChannelView.model.playAtIndex(4)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F6", "6"]
+                    onActivated: stationChannelView.model.playAtIndex(5)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F7", "7"]
+                    onActivated: stationChannelView.model.playAtIndex(6)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F8", "8"]
+                    onActivated: stationChannelView.model.playAtIndex(7)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F9", "9"]
+                    onActivated: stationChannelView.model.playAtIndex(8)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F10", "0"]
+                    onActivated: stationChannelView.model.playAtIndex(9)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F11", "Ctrl+1"]
+                    onActivated: stationChannelView.model.playAtIndex(10)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["F12", "Ctrl+2"]
+                    onActivated: stationChannelView.model.playAtIndex(11)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+3"]
+                    onActivated: stationChannelView.model.playAtIndex(12)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+4"]
+                    onActivated: stationChannelView.model.playAtIndex(13)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+5"]
+                    onActivated: stationChannelView.model.playAtIndex(14)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+6"]
+                    onActivated: stationChannelView.model.playAtIndex(15)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+7"]
+                    onActivated: stationChannelView.model.playAtIndex(16)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+8"]
+                    onActivated: stationChannelView.model.playAtIndex(17)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+9"]
+                    onActivated: stationChannelView.model.playAtIndex(18)
+                }
+                Shortcut {
+                    context: Qt.ApplicationShortcut; autoRepeat: false; sequences: ["Ctrl+0"]
+                    onActivated: stationChannelView.model.playAtIndex(19)
+                }
             }
 
             RowLayout {
@@ -829,6 +981,13 @@ ApplicationWindow {
     onVisibilityChanged: {
         if(visibility === Window.Minimized)
             guiHelper.tryHideWindow()
+    }
+
+    Shortcut {
+        context: Qt.ApplicationShortcut
+        autoRepeat: false
+        sequences: [StandardKey.Quit]
+        onActivated: guiHelper.close()
     }
 
     function updateTheme() {

--- a/src/welle-gui/QML/RadioView.qml
+++ b/src/welle-gui/QML/RadioView.qml
@@ -1,4 +1,4 @@
-﻿import QtQuick 2.2
+﻿import QtQuick 2.9
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 2.3
 import QtGraphicalEffects 1.0

--- a/src/welle-gui/QML/components/StationListModel.qml
+++ b/src/welle-gui/QML/components/StationListModel.qml
@@ -59,6 +59,53 @@ ListModel {
         }
     }
 
+    function getIndex(sIdDec, channel) {
+        for(var i=0; i<count; i++) {
+            if(get(i).stationSId == sIdDec && get(i).channelName === channel) {
+                return i
+            }
+        }
+    }
+
+    function getIndexPrevious(sIdDec, channel) {
+        for(var i=0; i<count; i++) {
+            if(get(i).stationSId == sIdDec && get(i).channelName === channel) {
+                return Math.max(0, i-1)
+            }
+        }
+        console.debug("Station '" + sIdDec + "' not found in this list. Returning index 0")
+        return 0
+    }
+
+    function getIndexNext(sIdDec, channel) {
+        for(var i=0; i<count; i++) {
+            if(get(i).stationSId == sIdDec && get(i).channelName === channel) {
+                return Math.min(count-1, i+1)
+            }
+        }
+        console.debug("Station '" + sIdDec + "' not found in this list. Returning index 0")
+        return 0
+    }
+
+    function play(channel, sidHex) {
+        var sidDec = parseInt(sidHex,16);
+        var stationName = getStationName(sidDec, channel)
+        //console.debug("stationName: " + stationName + " channel: " + channel + " sidHex: "+ sidHex)
+        if (!channel || !sidHex || !stationName) {
+            infoMessagePopup.text = qsTr("Last played station not found.\nSelect a station to start playback.");
+            infoMessagePopup.open();
+        } else {
+            radioController.play(channel, stationName, sidDec)
+        }
+    }
+
+    function playAtIndex(index) {
+        if (index < count) {
+            //console.debug("stationName: " + get(index).stationName + " channel: " + get(index).channelName + " sidDec: " + get(index).stationSId)
+            radioController.play(get(index).channelName, get(index).stationName, get(index).stationSId)
+        }
+    }
+
     // Necessary workaround because the settings component doesn't saves models
     function serialize() {
         var tmp = []

--- a/src/welle-gui/QML/components/WComboBox.qml
+++ b/src/welle-gui/QML/components/WComboBox.qml
@@ -25,6 +25,11 @@ ComboBox {
         highlighted: comboBox.highlightedIndex === index
     }
 
+    Keys.onShortcutOverride: {
+        if (event.key == Qt.Key_M || event.key == Qt.Key_S || event.key == Qt.Key_P || event.key == Qt.Key_N)
+            event.accepted = true
+    }
+
     TextMetrics {
         id: textMetrics
     }

--- a/src/welle-gui/QML/components/WComboBoxList.qml
+++ b/src/welle-gui/QML/components/WComboBoxList.qml
@@ -25,6 +25,11 @@ ComboBox {
         highlighted: comboBox.highlightedIndex === index
     }
 
+    Keys.onShortcutOverride: {
+        if (event.key == Qt.Key_M || event.key == Qt.Key_S || event.key == Qt.Key_P || event.key == Qt.Key_N)
+            event.accepted = true
+    }
+
     TextMetrics {
         id: textMetrics
     }


### PR DESCRIPTION
F1-F12, 1-9, 0, Ctrl+1-9, Ctrl+0: Play the station no. 'x' in the stations list (from 1 to 20)
S, Media Play, Media Stop, Media Pause, Media Play/Pause: Start playback/Stop
N, Media next: play next station in list
P, Media Previous: play previous station
M, Volume Mute: mute/unmute
Ctrl+Up, Volume Up: Volume Up
Ctrl+Down, Volume Down: Volume Down

Using "Space" for play/stop interferes with other widgets (comboboxes, buttons, switches...) so I used "S" instead (S like start/stop)