### PR TITLE
Pass SoapySDR arguments when setting up stream

### DIFF
--- a/src/backend.pri
+++ b/src/backend.pri
@@ -56,7 +56,7 @@ macx {
     LIBS    += -lmp3lame
     CONFIG  += airspy
     CONFIG  += rtl_sdr
-    #CONFIG  += soapysdr
+    CONFIG  += soapysdr
 }
 
 android {

--- a/src/input/soapy_sdr.cpp
+++ b/src/input/soapy_sdr.cpp
@@ -344,7 +344,8 @@ void CSoapySdr::workerthread()
     std::vector<size_t> channels;
     channels.push_back(0);
     std::clog << " *************** Setup soapy stream" << std::endl;
-    auto stream = m_device->setupStream(SOAPY_SDR_RX, "CF32", channels);
+    auto args = SoapySDR::KwargsFromString(m_driver_args);
+    auto stream = m_device->setupStream(SOAPY_SDR_RX, "CF32", channels, args);
 
     m_device->activateStream(stream);
     try {


### PR DESCRIPTION
This fixes the issue I described in #634, allowing me to set soapy-device-specific arguments so that I can connect using SoapyRemote. Perhaps someone more knowledgeable with SoapySDR can check whether it's the correct thing to do.

I've also enabled SoapySDR in the .pri file for macos, I can revert that if there's a reason it was disabled.