### PR TITLE
Disable some Qml warnings

### DIFF
--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -63,6 +63,16 @@ int main(int argc, char** argv)
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 //    QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);
 
+    // Disable a lot of new Qml warnings since Qt 5.15:
+    //
+    // Warning: qrc:/QML/settingpages/GlobalSettings.qml:37:5:
+    //   QML Connections: Implicitly defined onFoo properties in Connections are deprecated.
+    //   Use this syntax instead: function onFoo(<arguments>) { ... }
+    //
+    // Ref: https://zren.github.io/2020/06/19/qml-connections-onfoo-warnings-will-get-logging-category-in-qt-5151
+    //
+    qputenv("QT_LOGGING_RULES", "qt.qml.connections=false");
+    
     // Handle debug output
     CDebugOutput::init();
 


### PR DESCRIPTION
Since Qt 5.15 (I believe), there have been a lot of new Qml warnings like:
```
Warning: qrc:/QML/MainView.qml:884:9: QML Connections: 
Implicitly defined onFoo properties in Connections are deprecated. Use this syntax instead: function onFoo(<arguments>) { ... }
```

Simply adding `QT_LOGGING_RULES="qt.qml.connections=false"` to the environment will disable these warnings.
And *only* these it seems.

Ref: https://zren.github.io/2020/06/19/qml-connections-onfoo-warnings-will-get-logging-category-in-qt-5151