### PR TITLE
Replace __TIMESTAMP__ to get reproducible build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,9 @@ if(GIT_DESCRIBE)
   add_definitions("-DGITDESCRIBE=\"${GIT_DESCRIBE}\"")
 endif()
 
+STRING(TIMESTAMP BUILD_DATE "%s" UTC)
+add_definitions("-DBUILD_DATE=\"${BUILD_DATE}\"")
+
 if(BUILD_WELLE_IO)
     set(executableName welle-io)
     add_executable (${executableName} ${welle_io_sources} ${backend_sources} ${input_sources} ${fft_sources} ${EXTRA_MOCS} src/welle-gui/resources.qrc)

--- a/src/welle-gui/gui_helper.cpp
+++ b/src/welle-gui/gui_helper.cpp
@@ -181,8 +181,13 @@ const QByteArray CGUIHelper::getInfoPage(QString pageName)
         // Set application version
         InfoContent.append(tr("welle.io version") + ": " + QString(CURRENT_VERSION) + "\n");
         InfoContent.append(tr("Git revision") + ": " + QString(GITHASH) + "\n");
-        QString ts = QString(__TIMESTAMP__).replace("  "," ");
-        QDateTime tsDT = QLocale(QLocale::C).toDateTime(ts, "ddd MMM d hh:mm:ss yyyy");
+        QDateTime tsDT;
+        QString source_date_epoch = BUILD_DATE;
+        if (!source_date_epoch.isEmpty()) {
+            tsDT = QDateTime::fromSecsSinceEpoch(source_date_epoch.toLongLong());
+        } else {
+            tsDT = QDateTime::currentDateTime();
+        }
         InfoContent.append(tr("Built on") + ": " + tsDT.toString(Qt::ISODate) + "\n");
         InfoContent.append(tr("QT version") + ": " + qVersion() + "\n");
         InfoContent.append("\n");

--- a/src/welle-gui/welle-gui.pro
+++ b/src/welle-gui/welle-gui.pro
@@ -131,13 +131,31 @@ android {
         mpris/mpris_mp2_player.h
 }
 
-# Include git hash into build
+# Include git hash & BUILD_DATE into build
 unix: {
     GITHASHSTRING = $$system(git rev-parse --short HEAD)
+    isEmpty(SOURCE_DATE_EPOCH) {
+        SOURCE_DATE_EPOCH=$$(SOURCE_DATE_EPOCH)
+    }
+    isEmpty(SOURCE_DATE_EPOCH) {
+        SOURCE_DATE_EPOCH=$$system(git log -1 --pretty=%ct)
+    }
+    isEmpty(SOURCE_DATE_EPOCH) {
+        SOURCE_DATE_EPOCH=$$system(date +%s)
+    }
 }
 
 win32 {
     GITHASHSTRING = $$system(git.exe rev-parse --short HEAD)
+    isEmpty(SOURCE_DATE_EPOCH) {
+        SOURCE_DATE_EPOCH=$$(SOURCE_DATE_EPOCH)
+    }
+    isEmpty(SOURCE_DATE_EPOCH) {
+        SOURCE_DATE_EPOCH=$$system(git.exe log -1 --pretty=%ct)
+    }
+    isEmpty(SOURCE_DATE_EPOCH) {
+        SOURCE_DATE_EPOCH=$$system(powershell -Command (Get-Date -UFormat %s -Millisecond 0))
+    }
 } else:macx {
     ICON = icons/icon.icns
 }
@@ -148,4 +166,12 @@ win32 {
 }
 else {
     warning("Can't get git hash.")
+}
+
+!isEmpty(SOURCE_DATE_EPOCH) {
+    message("BUILD_DATE = $$SOURCE_DATE_EPOCH")
+    DEFINES += BUILD_DATE=\\\"$$SOURCE_DATE_EPOCH\\\"
+}
+else {
+    warning("BUILD_DATE could not be set.")
 }


### PR DESCRIPTION
Right now, build is not reproducible because it uses the __TIMESTAMP__ macro which changes at every build
To achieve reproducible build, replace it by BUILD_DATE set by either qmake or cmake and which uses SOURCE_DATE_EPOCH env var if set, otherwise timestamp of last git commit, otherwise current timestamp.

See https://reproducible-builds.org/docs/source-date-epoch/ for more details.