### PR TITLE
gui: update ApplicationDescription in commandLineParser

### DIFF
--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv)
 
     // Handle the command line
     QCommandLineParser optionParser;
-    optionParser.setApplicationDescription("welle.io Help");
+    optionParser.setApplicationDescription("welle.io is an open source DAB and DAB+ software defined radio (SDR) with support for rtl-sdr (RTL2832U) and airspy. It supports high DPI and touch displays and it runs even on cheap computers like Raspberry Pi 2/3 and 100€ China Windows 10 tablets.");
     optionParser.addHelpOption();
     optionParser.addVersionOption();
 


### PR DESCRIPTION
Useful for manpage generation which are built with "help2man" (see PR #689)

output of `welle-io -h`
```
Usage: welle-io [options]
welle.io is an open source DAB and DAB+ software defined radio (SDR) with support for rtl-sdr (RTL2832U) and airspy. It supports high DPI and touch displays and it runs even on cheap computers like Raspberry Pi 2/3 and 100€ China Windows 10 tablets.

Options:
  -h, --help                Displays help on commandline options.
  --help-all                Displays help including Qt specific options.
  -v, --version             Displays version information.
  --dump-file <File name>   Records DAB frames (*.mp2) or DAB+ superframes with
                            RS coding (*.dab). This file can be used to analyse
                            X-PAD data with XPADxpert
  --log-file <File name>    Redirects all log output texts to a file.
  --qqc-style <Style name>  Qt Quick Controls Style for the 1st launch
```