### PR TITLE
Fix typing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you discovered an issue please open a new [issue](https://github.com/Albrecht
 ##### Developer version
 welle.io is under heavy development. You can also try the latest developer builds. But PLEASE BE WARNED the builds are automatically created and untested.
  * [welle.io nightly builds for *Windows* & *Linux AppImage*](https://welle-io-nightlies.albrechtloh.de/)
- * welle.io devel builds on *macOS MacPorts* are updated perdiodically manually and can be installed through [port welle.io-devel](https://ports.macports.org/port/welle.io-devel/summary). The port has no maintainer so please feel free to update it yourself in case you need to use a more recent devel version.
+ * welle.io devel builds on *macOS MacPorts* are updated periodically manually and can be installed through [port welle.io-devel](https://ports.macports.org/port/welle.io-devel/summary). The port has no maintainer so please feel free to update it yourself in case you need to use a more recent devel version.
    * `sudo port install welle.io-devel`
 
 ##### Compilation from source
@@ -124,12 +124,12 @@ Ubuntu Linux 18.04 LTS
 ---
 This section shows how to compile welle.io on Ubuntu 16.04 LTS and Ubuntu 18.04 LTS. 
 
-1. Install Qt 5.10 including the Qt Charts module by using the the "Qt Online Installer for Linux" https://www.qt.io/download-open-source/
+1. Install Qt 5.10 including the Qt Charts module by using the "Qt Online Installer for Linux" https://www.qt.io/download-open-source/
 
 2. Install the following packages
 
   ```
-# sudo apt install libfaad-dev libmpg123-dev libmpg123-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev libairspy-dev libmp3lame-dev
+# sudo apt install libfaad-dev libmpg123-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev libairspy-dev libmp3lame-dev
   ```
 
 3. Clone welle.io
@@ -148,7 +148,7 @@ A compiled version can be found at the [release page](https://github.com/Albrech
 
 This sections shows how to compile welle.io on Windows 10. Windows 7 should also be possible but is not tested. 
 
-1. Install Qt 5.10 including the Qt Charts and mingw modules by using the the "Qt Online Installer for Windows" https://www.qt.io/download-open-source/
+1. Install Qt 5.10 including the Qt Charts and mingw modules by using the "Qt Online Installer for Windows" https://www.qt.io/download-open-source/
 2. Clone welle.io https://github.com/AlbrechtL/welle.io.git e.g. by using [TortoiseGit](https://tortoisegit.org).
 3. Clone the welle.io Windows libraries https://github.com/AlbrechtL/welle.io-win-libs.git.
 4. Start Qt Creator and open the project file `welle.io.pro` inside the folder "welle.io".
@@ -282,7 +282,7 @@ welle.io uses the "RTL2832U driver" from Martin Marinov, to be found at the [Goo
 
 This sections shows how to compile welle.io for Android.
 
-1. Install Qt 5.12 for Android including the Qt Charts and Qt Remote Objects modules by using the the "Qt Online Installer for Windows" https://www.qt.io/download-open-source/
+1. Install Qt 5.12 for Android including the Qt Charts and Qt Remote Objects modules by using the "Qt Online Installer for Windows" https://www.qt.io/download-open-source/
 2. Follow the side https://doc.qt.io/qt-5/androidgs.html to install the Android build environment
 3. Clone welle.io https://github.com/AlbrechtL/welle.io.git
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ welle.io uses the "RTL2832U driver" from Martin Marinov, to be found at the [Goo
 This sections shows how to compile welle.io for Android.
 
 1. Install Qt 5.12 for Android including the Qt Charts and Qt Remote Objects modules by using the the "Qt Online Installer for Windows" https://www.qt.io/download-open-source/
-2. Follow the side https://doc.qt.io/qt-5/androidgs.html to install the Android build enviroment
+2. Follow the side https://doc.qt.io/qt-5/androidgs.html to install the Android build environment
 3. Clone welle.io https://github.com/AlbrechtL/welle.io.git
 
   ```
@@ -366,7 +366,7 @@ Examples:
 
 Limitations
 ===
-* Windows 8 and older are not offically supported
+* Windows 8 and older are not officially supported
 
 Development
 ===

--- a/src/backend/dab-constants.cpp
+++ b/src/backend/dab-constants.cpp
@@ -31,7 +31,7 @@
 #include <exception>
 #include <sstream>
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
     #include <QtGlobal>
 #else
@@ -274,7 +274,7 @@ const char* DABConstants::getLanguageName(int language)
         case 70: languageName = QT_TR_NOOP("Vietnamese"); break;
         case 71: languageName = QT_TR_NOOP("Uzbek"); break;
         case 72: languageName = QT_TR_NOOP("Urdu"); break;
-        case 73: languageName = QT_TR_NOOP("Ukranian"); break;
+        case 73: languageName = QT_TR_NOOP("Ukrainian"); break;
         case 74: languageName = QT_TR_NOOP("Thai"); break;
         case 75: languageName = QT_TR_NOOP("Telugu"); break;
         case 76: languageName = QT_TR_NOOP("Tatar"); break;

--- a/src/backend/decoder_adapter.cpp
+++ b/src/backend/decoder_adapter.cpp
@@ -37,7 +37,7 @@ DecoderAdapter::DecoderAdapter(ProgrammeHandlerInterface &mr, int16_t bitRate, A
     else if (dabModus == AudioServiceComponentType::DABPlus)
         decoder = std::make_unique<SuperframeFilter>(this, true, false);
     else
-        throw std::runtime_error("DecoderAdapter: Unkonwn service component");
+        throw std::runtime_error("DecoderAdapter: Unknown service component");
 
     // Open a dump file (XPADxpert) if the user defined it
     if (!dumpFileName.empty()) {
@@ -94,8 +94,8 @@ void DecoderAdapter::PutAudio(const uint8_t *data, size_t len)
 {
     // Then len is given in bytes. For stereo it is the double times of mono.
     // But we need two channels even if we have mono.
-    // Mono: len = len / 2 * 2 We have len to devide by 2 and for two channels we have multiply by two
-    // Stereo: len = len / 2 We just need to devide by 2 because it is stereo
+    // Mono: len = len / 2 * 2 We have len to divide by 2 and for two channels we have multiply by two
+    // Stereo: len = len / 2 We just need to divide by 2 because it is stereo
     size_t bufferSize = audioChannels == 2 ? len/2 : len;
     std::vector<int16_t> audio(bufferSize);
 

--- a/src/backend/eep-protection.cpp
+++ b/src/backend/eep-protection.cpp
@@ -140,7 +140,7 @@ bool EEPProtection::deconvolve(const softbit_t *v, int32_t size, uint8_t *outBuf
         }
     }
     //  we had a final block of 24 bits  with puncturing according to PI_X
-    //  This block constitues the 6 * 4 bits of the register itself.
+    //  This block constitutes the 6 * 4 bits of the register itself.
     for (i = 0; i < 24; i ++) {
         if (PI_X [i] != 0)
             viterbiBlock[viterbiCounter] = v [inputCounter ++];

--- a/src/backend/fic-handler.cpp
+++ b/src/backend/fic-handler.cpp
@@ -181,7 +181,7 @@ void FicHandler::processFicInput(const softbit_t *ficblock, int16_t ficno)
 
     /**
      * we have a final block of 24 bits  with puncturing according to PI_X
-     * This block constitues the 6 * 4 bits of the register itself.
+     * This block constitutes the 6 * 4 bits of the register itself.
      */
     for (k = 0; k < 24; k ++) {
         if (PI_X [k] != 0) {

--- a/src/backend/ofdm-processor.cpp
+++ b/src/backend/ofdm-processor.cpp
@@ -230,7 +230,7 @@ void OFDMProcessor::getSamples(DSPCOMPLEX *v, int16_t n, int32_t phase)
  *    time synchronization and frequency synchronization
  *    Identifying symbols in the DAB frame
  *    and sending them to the ofdmDecoder who will transfer the results
- *    Finally, estimating the small freqency error
+ *    Finally, estimating the small frequency error
  */
 void OFDMProcessor::run()
 {

--- a/src/backend/radio-controller.h
+++ b/src/backend/radio-controller.h
@@ -132,7 +132,7 @@ class RadioControllerInterface {
         virtual void onInputFailure(void) { };
 };
 
-/* A Programme Hander is associated to each tuned programme in the ensemble.
+/* A Programme Handler is associated to each tuned programme in the ensemble.
  */
 class ProgrammeHandlerInterface {
     public:

--- a/src/backend/uep-protection.cpp
+++ b/src/backend/uep-protection.cpp
@@ -223,7 +223,7 @@ bool UEPProtection::deconvolve(const softbit_t *v, int32_t size, uint8_t *outBuf
 
     /**
      * we have a final block of 24 bits  with puncturing according to PI_X
-     * This block constitues the 6 * 4 bits of the register itself.
+     * This block constitutes the 6 * 4 bits of the register itself.
      */
     for (i = 0; i < 24; i ++) {
         if (PI_X[i] != 0) {

--- a/src/input/airspy_sdr.cpp
+++ b/src/input/airspy_sdr.cpp
@@ -35,7 +35,7 @@
 #include <iostream>
 #include "airspy_sdr.h"
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
     #include <QtGlobal>
 #else

--- a/src/input/input_factory.cpp
+++ b/src/input/input_factory.cpp
@@ -28,7 +28,7 @@
 
 #include <iostream>
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
     #include <QtGlobal>
 #else
@@ -71,7 +71,7 @@ CVirtualInput *CInputFactory::GetDevice(RadioControllerInterface& radioControlle
     else
         InputDevice = GetManualDevice(radioController, device);
 
-    // Fallback if no device is found or an error occured
+    // Fallback if no device is found or an error occurred
     if (InputDevice == nullptr) {
         std::string text;
 
@@ -119,7 +119,7 @@ CVirtualInput *CInputFactory::GetDevice(RadioControllerInterface &radioControlle
             "Error while opening device \"" << static_cast<int>(deviceId) << "\"." << std::endl;
     }
 
-    // Fallback if no device is found or an error occured
+    // Fallback if no device is found or an error occurred
     if (InputDevice == nullptr) {
         std::string text = QT_TRANSLATE_NOOP("CRadioController", "Error while opening device");
         radioController.onMessage(message_level_t::Error, text);
@@ -153,7 +153,7 @@ CVirtualInput* CInputFactory::GetAutoDevice(RadioControllerInterface& radioContr
             }
         }
         catch (...) {
-            // An error occured. Maybe the device isn't present.
+            // An error occurred. Maybe the device isn't present.
             // Just try the next input device
         }
 

--- a/src/input/limesdr.cpp
+++ b/src/input/limesdr.cpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include "limesdr.h"
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
 #include <QtGlobal>
 #else

--- a/src/input/raw_file.cpp
+++ b/src/input/raw_file.cpp
@@ -41,7 +41,7 @@
 
 #include "raw_file.h"
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
     #include <QtGlobal>
 #else

--- a/src/input/rtl_sdr.cpp
+++ b/src/input/rtl_sdr.cpp
@@ -35,7 +35,7 @@
 
 #include "rtl_sdr.h"
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
     #include <QtGlobal>
 #else
@@ -71,7 +71,7 @@ void CRTL_SDR::open_device()
         std::clog << "RTL_SDR: " << "Found " << deviceCount << " devices. Uses the first working one" << std::endl;
     }
 
-    //	Iterate over all found rtl-sdr devices and try to open it. Stops if one device is successfull opened.
+    //	Iterate over all found rtl-sdr devices and try to open it. Stops if one device is successful opened.
     for(uint32_t i=0; i<deviceCount; i++) {
         ret = rtlsdr_open(&device, i);
         if (ret >= 0) {
@@ -138,7 +138,7 @@ bool CRTL_SDR::restart(void)
         try {
             open_device();
         } catch (...) {
-            // An error occured. Maybe the device isn't present.
+            // An error occurred. Maybe the device isn't present.
             radioController.onMessage(message_level_t::Error, QT_TRANSLATE_NOOP("CRadioController", "Error opening RTL-SDR. See log for details."));
             return false;
         }

--- a/src/input/rtl_tcp.cpp
+++ b/src/input/rtl_tcp.cpp
@@ -35,7 +35,7 @@
 
 #include "rtl_tcp.h"
 
-// For Qt translation if Qt is exisiting
+// For Qt translation if Qt is existing
 #ifdef QT_CORE_LIB
     #include <QtGlobal>
 #else

--- a/src/tests/backend_tests.cpp
+++ b/src/tests/backend_tests.cpp
@@ -132,7 +132,7 @@ void BackendTests::runRadio(const std::string &rawFileName,
                 }
                 else
                 {
-                    std::cout << "Tune to " << service.serviceLabel.utf8_label() << " succesfully" << std::endl;
+                    std::cout << "Tune to " << service.serviceLabel.utf8_label() << " successfully" << std::endl;
                     service_selected = true;
                 }
                 break;

--- a/src/various/channels.cpp
+++ b/src/various/channels.cpp
@@ -118,7 +118,7 @@ int Channels::getFrequency(const string& channelName)
     currentFrequency = frequency;
     currentChannel = channelName;
 
-    // Get index of current fequency
+    // Get index of current frequency
     for (int i=0; i<NUMBEROFCHANNELS; i++) {
         if (getChannelNameAtIndex(i) == channelName) {
             currentFrequencyIndex = i;

--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -88,7 +88,7 @@ ApplicationWindow {
             mainWindow.height = getHeight()
         }
 
-        // Show error message if one occured during startup
+        // Show error message if one occurred during startup
         if(errorMessagePopup.text != "")
             errorMessagePopup.open();
 
@@ -131,8 +131,8 @@ ApplicationWindow {
                     else
                     {
                         // Workaround for touch displays. (Discovered with Windows 10)
-                        // For some reason the dawer will be closed before it is openend
-                        // Disbale closing
+                        // For some reason the dawer will be closed before it is opened
+                        // Disable closing
                         stationDrawer.closePolicy = Popup.NoAutoClose
 
                         // Open drawer
@@ -351,7 +351,7 @@ ApplicationWindow {
 
                         parent: Overlay.overlay
 
-                        //modal: true  //if 'true', double click on the speaker icon will not be catched
+                        //modal: true  //if 'true', double click on the speaker icon will not be caught
                         focus: true
                         closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
@@ -516,7 +516,7 @@ ApplicationWindow {
         visible: !inPortrait
 
         // Workaround for touch displays. (Discovered with Windows 10)
-        // For some reason the dawer will be closed before it is openend
+        // For some reason the dawer will be closed before it is opened
         // Enable closing again
         onOpened: closePolicy = Popup.CloseOnEscape | Popup.CloseOnPressOutside
 
@@ -999,7 +999,7 @@ ApplicationWindow {
         onMaximizeWindow: showMaximized()
         onRestoreWindow: {
             // On Linux (KDE?): Hide before we restore 
-            // otherwise the window will occasionaly not be brought to the front
+            // otherwise the window will occasionally not be brought to the front
             if (Qt.platform.os === "linux" && !active) // Linux Workaround to display the window
                 hide()
             showNormal()

--- a/src/welle-gui/QML/components/ViewBaseFrame.qml
+++ b/src/welle-gui/QML/components/ViewBaseFrame.qml
@@ -60,7 +60,7 @@ Rectangle {
         }
     }
 
-    // Posibility to add options entries dynamically
+    // Possibility to add options entries dynamically
     function addEntry(title, onTriggered) {
         var obj = menuItem.createObject(menu, {text: title})
         obj.triggered.connect(onTriggered)

--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char** argv)
     CGUIHelper guiHelper(&radioController);
     guiHelper.setTranslator(translator);
 
-    // Create new QML application, set some requried options and load the QML file
+    // Create new QML application, set some required options and load the QML file
     QQmlApplicationEngine engine;
     QQmlContext* rootContext = engine.rootContext();
 

--- a/src/welle-gui/waterfallitem.cpp
+++ b/src/welle-gui/waterfallitem.cpp
@@ -167,7 +167,7 @@ void WaterfallItem::samplesCollected() {
 
     // Draw message into the plot
     if(!messageToPlot.isEmpty()) {
-        // Draw everthing in black
+        // Draw everything in black
         painter.setPen(QColor("black"));
 
         // Draw horizontal line

--- a/windows/create_installer.ps1
+++ b/windows/create_installer.ps1
@@ -79,5 +79,5 @@ $Filename = $Date + "_" + $gitHash + "_Windows_welle-io-setup.exe"
 Write-Host "*** Creating $Filename ***" -ForegroundColor Red
 & "binarycreator" "--offline-only" "--config" "installer\config\config.xml" "--packages" "installer\packages" "$Filename"
 
-# Store file name to a enviroment variable
+# Store file name to a environment variable
 $env:welle_io_filename = $Filename


### PR DESCRIPTION
Fixed with:
codespell --skip=*/i18n/*,*/libs/*,*/strings.xml --ignore-words-list=ba,isplay,mot,nd,te --write-changes

Most changes are in comments, 3 changes are in strings and seems safe to apply:
```
[...]
+        case 73: languageName = QT_TR_NOOP("Ukrainian"); break;
[...]
+        throw std::runtime_error("DecoderAdapter: Unknown service component")
[...]
+                    std::cout << "Tune to " << service.serviceLabel.utf8_label() << " successfully" << std::endl;
[...]
```