### PR TITLE
Add AppStream metadata file for welle-io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,10 +119,10 @@ jobs:
         - mv welle.io-cli-"$GIT_HASH"-x86_64.AppImage "$DATE"_"$GIT_HASH"_Linux_welle-io-cli-x86_64.AppImage
         
         # Create welle-gui Flatpak
-        - sudo flatpak-builder --repo=wellerepo --force-clean fp_build io.welle.welle-gui.json
+        - sudo flatpak-builder --repo=wellerepo --force-clean fp_build io.welle.welle_io.json
         - sudo flatpak --user remote-add --no-gpg-verify welle-repo wellerepo
-        - sudo flatpak --user install welle-repo io.welle.welle-gui --assumeyes
-        - flatpak build-bundle wellerepo welle-io.flatpak io.welle.welle-gui
+        - sudo flatpak --user install welle-repo io.welle.welle_io --assumeyes
+        - flatpak build-bundle wellerepo welle-io.flatpak io.welle.welle_io
         - mv welle-io.flatpak "$DATE"_"$GIT_HASH"_Linux_welle-io-x86_64.flatpak
 
         # Upload

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ if(BUILD_WELLE_IO)
 
         if(UNIX AND NOT APPLE)
             INSTALL (FILES ${PROJECT_SOURCE_DIR}/welle-io.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+            INSTALL (FILES ${PROJECT_SOURCE_DIR}/io.welle.welle_io.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 
             INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icons/16x16/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps)
             INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icons/24x24/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps)

--- a/io.welle.welle_io.json
+++ b/io.welle.welle_io.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "io.welle.welle-gui",
+    "app-id": "io.welle.welle_io",
     "runtime": "org.kde.Platform",
     "runtime-version": "5.15",
     "sdk": "org.kde.Sdk",

--- a/io.welle.welle_io.metainfo.xml
+++ b/io.welle.welle_io.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2022 Albrecht Lohofener <albrechtloh@gmx.de> -->
+<component type="desktop-application">
+  <id>io.welle.welle_io</id>
+  <launchable type="desktop-id">welle-io.desktop</launchable>
+  <name>welle.io</name>
+  <summary>A DAB/DAB+ Software Radio</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <developer_name>Albrecht Lohofener</developer_name>
+  <url type="homepage">https://www.welle.io</url>
+  <description>
+    <p>
+      welle.io is an open source DAB and DAB+ software defined radio (SDR) with support for rtl-sdr (RTL2832U), airspy and other devices supported by SoapySDR.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.welle.io/images/welle-io_standard_mode.png</image>
+    </screenshot>
+  </screenshots>
+  <update_contact>albrechtloh@gmx.de</update_contact>
+  <content_rating type="oars-1.1" />
+</component>


### PR DESCRIPTION
Closes #718.

I have also renamed the Flatpak file id to match the AppStream id.