### PR TITLE
Append theme path from resources

### DIFF
--- a/src/welle-gui/main.cpp
+++ b/src/welle-gui/main.cpp
@@ -93,7 +93,7 @@ int main(int argc, char** argv)
     qRegisterMetaType<mot_file_t>("mot_file_t");
 
     // Set icon path
-    QStringList themePaths;
+    QStringList themePaths = QIcon::themeSearchPaths();
     themePaths << ":/icons/welle_io_icons";
     QIcon::setThemeSearchPaths(themePaths);
     QIcon::setThemeName("welle_io_icons");


### PR DESCRIPTION
Fixes issue #713.

Appending would allow local icons to take precedence over those bundled.

Calling `QIcon::setThemeSearchPaths(themePaths);` replaces the whole list of paths which results in missing icons on some systems.
Adding `qDebug() << QIcon::themeSearchPaths();` before and after the call to `setThemeSearchPaths()` before this patch:
```
2022-03-11T20:12:10.344 Debug: ("/home/user/.local/share/icons", "/usr/share/icons", "/var/lib/snapd/desktop/icons", ":/icons")
2022-03-11T20:12:10.344 Debug: (":/icons/welle_io_icons")
```
after this patch:
```
2022-03-11T20:14:59.384 Debug: ("/home/user/.local/share/icons", "/usr/share/icons", "/var/lib/snapd/desktop/icons", ":/icons")
2022-03-11T20:14:59.384 Debug: ("/home/user/.local/share/icons", "/usr/share/icons", "/var/lib/snapd/desktop/icons", ":/icons", ":/icons/welle_io_icons")
```
and all the icons are visible for me.