### PR TITLE
Feature/scanbutton

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -575,8 +575,6 @@ ApplicationWindow {
                             font.pixelSize: TextStyle.textStandartSize
                             font.family: TextStyle.textFont
                             onTriggered:  {
-                                startStationScanItem.enabled = false
-                                stopStationScanItem.enabled = true
                                 radioController.startScan()
                             }
                         }
@@ -588,8 +586,6 @@ ApplicationWindow {
                             font.family: TextStyle.textFont
                             enabled: false
                             onTriggered:  {
-                                startStationScanItem.enabled = true
-                                stopStationScanItem.enabled = false
                                 radioController.stopScan()
                             }
                         }

--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -617,6 +617,16 @@ ApplicationWindow {
                 Layout.margins: Units.dp(10)
             }
 
+            Button {
+                id: startStationScanButton
+                text: qsTr("Start station scan")
+                visible: stationChannelView.count ? false : true
+                onClicked:  {
+                    radioController.startScan()
+                }
+                Layout.margins: Units.dp(10)
+            }
+
             ListView {
                 id: stationChannelView
                 model: stationList
@@ -978,11 +988,13 @@ ApplicationWindow {
         onScanStopped:{
             startStationScanItem.enabled = true
             stopStationScanItem.enabled = false
+            startStationScanButton.enabled = true
         }
 
         onScanProgress:{
             startStationScanItem.enabled = false
             stopStationScanItem.enabled = true
+            startStationScanButton.enabled = false
         }
 
         onNewStationNameReceived: stationList.addStation(station, sId, channel, false)


### PR DESCRIPTION
This is my first try at fixing issue #701 
It adds a flat button whose enabled status tracks the status of the scanning like the existing menu items:
![image](https://user-images.githubusercontent.com/1055635/157961444-c697fd8b-ed77-46d6-9cbe-ed8317c0d202.png)
