### PR TITLE
index page: Add Fedora installation instructions

### DIFF
--- a/pages/pages-root-folder/index.md
+++ b/pages/pages-root-folder/index.md
@@ -71,6 +71,9 @@ Download
 * ### [**Windows**, **Linux**, **macOS** and **Android**](http://github.com/AlbrechtL/welle.io/releases) 
 * **Debian** or **Ubuntu** 19.04+
   * `apt install welle.io`
+* **Fedora** 35+ (uses the [RPM Fusion](https://rpmfusion.org) package sources)
+  * `sudo dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm` (to enable the RPM Fusion sources)
+  * `sudo dnf install --refresh welle-io`
 * **macOS** (requires [MacPorts](https://www.macports.org/)) 
    * `sudo port install welle.io`
    * `sudo port install welle.io +cli` (if you wish to install also welle-cli)


### PR DESCRIPTION
This adds the entry

-----
* **Fedora** 35+ (uses the [RPM Fusion](https://rpmfusion.org) package sources)
  * `sudo dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm` (to enable the RPM Fusion sources)
  * `sudo dnf install --refresh welle-io`
-----

below Debian/Ubuntu