### PR TITLE
web stream url with channel-switching support

### DIFF
--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -860,8 +860,9 @@ bool WebRadioInterface::send_mp3(Socket& s, const std::string& stream)
         for (const auto& srv : rx->getServiceList()) {
             if (rx->serviceHasAudioComponent(srv) and
                 (to_hex(srv.serviceId, 4) == stream or
-                 (uint32_t)std::stoul(stream) == srv.serviceId)) {
+                (uint32_t)std::stoul(stream) == srv.serviceId)) {
                     is_empty=false;
+
                     if (phs.count(srv.serviceId) == 0) {
                         WebProgrammeHandler ph(srv.serviceId);
                         phs.emplace(std::make_pair(srv.serviceId, move(ph)));

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -502,11 +502,21 @@ bool WebRadioInterface::dispatch_client(Socket&& client)
 
                 const regex regex_mp3(R"(^[/]mp3[/]([^ ]+))");
                 std::smatch match_mp3;
+
+                const regex regex_mp3channel(R"(^[/]mp3-channel[/]([^ ]+)[/]([^ ]+))");
+                std::smatch match_mp3channel;
+
                 if (regex_search(req.url, match_mp3, regex_mp3)) {
                     success = send_mp3(s, match_mp3[1]);
                 }
                 else if (regex_search(req.url, match_slide, regex_slide)) {
                     success = send_slide(s, match_slide[1]);
+                }
+                else if (regex_search(req.url, match_mp3channel, regex_mp3channel)) {
+                    success = handle_channel_post(s, match_mp3channel[1]);
+                    if (success) {
+                        success = send_mp3(s, match_mp3[2]);
+                    }
                 }
                 else {
                     cerr << "Could not understand GET request " << req.url << endl;


### PR DESCRIPTION
This is my implementation of the feature suggested in #356 .

Basically this allows better m3u playlist support, because the audio player can now automatically request a channel change before connecting to the audio stream.

This can be accessed at `/mp3-channel/<channel>/<program>`, this way the `/mp3/<program>` endpoint stays the same.
Basically requesting `/mp3-channel/` is the same as sending a POST request to `/channel`, waiting for the sync to finish and then requesting `/mp3/`.
But as simple audio players like kodi or vlc can not do that when playing back a `.m3u` file this new endpoint enables them to do this as one request.

This would allow the end user to have multiple different radio programs on different channels in the same playlist, e.g. (a couple of somewhat local radio stations)
```m3u
#EXTM3U
#EXTINF:0,SAW
#EXTVLCOPT:network-caching=500
http://127.0.0.1:8080/mp3-channel/11C/0xd5d9
#EXTINF:0,MDR AKTUELL
#EXTVLCOPT:network-caching=500
http://127.0.0.1:8080/mp3-channel/6B/0xd3d5
```

Inside of kodi this would allow the user to choose between multiple different radio stations without the need to restart welle-cli or perform multiple network requests