### PR TITLE
fixed bug where /mp3 request would be caught in while loop

### DIFF
--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -875,6 +875,7 @@ bool WebRadioInterface::send_mp3channel(Socket& s, const std::string& ch, const 
         }
     }
 
+    lock.unlock();
     send_mp3(s, stream);
 }
 

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -513,8 +513,7 @@ bool WebRadioInterface::dispatch_client(Socket&& client)
                     success = send_slide(s, match_slide[1]);
                 }
                 else if (regex_search(req.url, match_mp3channel, regex_mp3channel)) {
-                    retune(match_mp3channel[1]);
-                    success = send_mp3(s, match_mp3channel[2]);
+                    success = send_mp3channel(s, match_mp3channel[1], match_mp3channel[2]);
                 }
                 else {
                     cerr << "Could not understand GET request " << req.url << endl;
@@ -853,8 +852,10 @@ bool WebRadioInterface::send_mux_playlist(Socket& s)
     return true;
 }
 
-bool WebRadioInterface::send_mp3(Socket& s, const std::string& stream)
+bool WebRadioInterface::send_mp3channel(Socket& s, const std::string& ch, const std::string& stream)
 {
+    retune(ch);
+
     unique_lock<mutex> lock(rx_mut);
     ASSERT_RX;
 
@@ -873,6 +874,14 @@ bool WebRadioInterface::send_mp3(Socket& s, const std::string& stream)
             }
         }
     }
+
+    send_mp3(s, stream);
+}
+
+bool WebRadioInterface::send_mp3(Socket& s, const std::string& stream)
+{
+    unique_lock<mutex> lock(rx_mut);
+    ASSERT_RX;
 
     for (const auto& srv : rx->getServiceList()) {
         if (rx->serviceHasAudioComponent(srv) and

--- a/src/welle-cli/webradiointerface.h
+++ b/src/welle-cli/webradiointerface.h
@@ -114,6 +114,13 @@ class WebRadioInterface : public RadioControllerInterface {
         // Generate and send a m3u playlist with all services
         bool send_mux_playlist(Socket& s);
 
+        // Send an mp3 stream containing the selected programme
+        // and automatically tunes to the provided channel.
+        // ch is the channel, e.g. 11C
+        // stream is a service id, either in hex with 0x prefix or
+        // in decimal
+        bool send_mp3channel(Socket& s, const std::string& ch, const std::string& stream);
+
         // Send an mp3 stream containing the selected programme.
         // stream is a service id, either in hex with 0x prefix or
         // in decimal


### PR DESCRIPTION
this is because my old code would also introduce the while to the `/mp3` request and if the user forgot to tune before, the request would now wait instead of failing.
Caused by: #740 