### PR TITLE
automatic channel retune

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ With the `-P` option, welle-cli will switch once DLS and a slide were decoded, s
     
 Example: `welle-cli -c 12A -C 1 -w 7979` enables the webserver on channel 12A, please then go to http://localhost:7979/ where you can observe all necessary details for every service ID in the ensemble, see the slideshows, stream the audio (by clicking on the Play-Button), check spectrum, constellation, TII information and CIR peak diagramme.
 
+If using the webserver option (-w) the webserver can change channels when a station is choosen over the web with the correct m3u file.
+Such a m3u file can be made with a stationscan of welle.io.gui, make_station_json.sh and make_station_m3us.py. 
+If a streamer on your network activates such a m3u file it streams the station immediately if it is in the current channel (ensemble). If it is not, it changes to the desired channel and streams the station. 
+Such a channel change takes several seconds (up to 20 seconds) and the streamer most likely times out. Then you must try again.
+
 Backend options
 ---
 

--- a/make_stations_json.sh
+++ b/make_stations_json.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd ~/.config/welle.io
+grep stationListSerialize welle.io.conf | sed 's/stationListSerialize=\"// ; s/]\"/]/ ; s/\\//g'  > stations.json

--- a/make_stations_m3us.py
+++ b/make_stations_m3us.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import json
+
+server_ip_address = '10.0.2.217';
+server_port_nr    = '8888';
+
+def gen_m3u ( station ):
+    name = station [ 'stationName' ] . rstrip () 
+    sid  = station [ 'stationSId'  ]
+    chn  = station [ 'channelName' ]
+    print  ( name , hex(sid) , chn )
+    with open ( 'DAB '+name+'.m3u' , 'w' ) as p:
+        p.write ( '#EXTM3U\n#EXTINF:-1,1 '+name+'\nhttp://'+server_ip_address+':'+server_port_nr+'/mp3/'+hex(sid)+'/'+chn+'\n' )
+        p.close 
+
+with open('stations.json') as f:
+    stations = json.load(f)
+    for station in stations:
+        gen_m3u ( station )

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -239,6 +239,7 @@ void WebRadioInterface::check_decoders_required()
     }
     phs_changed.notify_all();
 }
+string chn;
 
 void WebRadioInterface::retune(const std::string& channel)
 {
@@ -250,6 +251,7 @@ void WebRadioInterface::retune(const std::string& channel)
         cerr << "RETUNE Invalid channel: " << channel << endl;
         return;
     }
+    chn = channel;
 
     cerr << "RETUNE: Retune to " << freq << endl;
 
@@ -501,10 +503,20 @@ bool WebRadioInterface::dispatch_client(Socket&& client)
                 std::smatch match_slide;
 
                 const regex regex_mp3(R"(^[/]mp3[/]([^ ]+))");
+                const regex regex_mp3_with_channel (R"(^[/]mp3[/]([^ ]+)[/]([^ ]+))");
                 std::smatch match_mp3;
-                if (regex_search(req.url, match_mp3, regex_mp3)) {
+
+                if (regex_search(req.url, match_mp3, regex_mp3_with_channel)) {
+                    if ( chn.compare(match_mp3[2]) != 0 ) {
+                         chn = match_mp3[2];
+                         retune ( chn );
+                    }
                     success = send_mp3(s, match_mp3[1]);
                 }
+                else if (regex_search(req.url, match_mp3, regex_mp3)) {
+                    success = send_mp3(s, match_mp3[1]);
+                }
+
                 else if (regex_search(req.url, match_slide, regex_slide)) {
                     success = send_slide(s, match_slide[1]);
                 }


### PR DESCRIPTION
It is the intention of this change that If you are using welle-cli with the webinterface you can choose any radiostation (as scanned bij welle.io) by means of an adapted m3u file. If a channel change is needed it will be done automatically. Because such a channel change takes some time your streamer will problably time out. Wait some seconds (untill after the channel change is completed , normally 10 seconds)  and choose the radiostation again.
In the m3u file for a specific radiostation the required channel is incorporated. You can craft such an m3u file with two helper files (in the root directory of this repository). You can also made them by hand by looking at the normal browser-webinterface of welle-cli. "old" m3u files still work but don't initiate a channel change.

The webinterface in a browser stll works as it used to be: you see only the radiostations of the currently chosen channel and you can change the channel by hand.

There are only a few changes in the file WebRadioInterface.cpp. Because I am not an experienced c++ programmer, maybe you can improve on some changes!

This is also my first attempt to use git and github  so please be gentle!