### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--
+Thank you for your interest in contributing to welle.io, it's highly appreciated!
+
+Please send PRs only against the branch "next".
+
+Describe your PR further using the template provided below.
+The more details the better, but please delete unsed sections!
+-->
+
+#### What does this PR do and why is it necessary?
+
+#### How was it tested? How can it be tested by the reviewer?
+
+#### Any background context you want to provide?
+
+#### What are the relevant tickets if any?
+
+#### Screenshots (if appropriate)
+
+#### Further notes


### PR DESCRIPTION
This PR add ads a pull request template containing instructions that will be hidden and some when the request is created (the text is copied with some modifications from [octoprint](https://raw.githubusercontent.com/OctoPrint/OctoPrint/master/.github/PULL_REQUEST_TEMPLATE.md)) as suggested in PR #737.

I'm sending this PR against the `next` branch, but it works only when the file is added to the default branch, [according to the docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#:~:text=Templates%20are%20available%20to%20collaborators%20when%20they%20are%20merged%20into%20the%20repository%27s%20default%20branch.).

This is how it looks like (click for a larger image):

<img src="https://user-images.githubusercontent.com/1055635/185812157-9e4c0b04-11a1-47ea-b3c0-f1c3de5e8577.png" width="500"/>
