### PR TITLE
welle-cli: disable software AGC in manual gain mode

### DIFF
--- a/src/input/rtl_tcp.cpp
+++ b/src/input/rtl_tcp.cpp
@@ -282,6 +282,12 @@ void CRTL_TCP_Client::receiveData(void)
                 dongleInfo.tuner_type << " " << TunerType << std::endl;
             std::clog << "RTL_TCP_CLIENT: Tuner gain count: " <<
                 dongleInfo.tuner_gain_count << std::endl;
+            
+            // Always use manual gain, the AGC is implemented in software
+            setGainMode(1);
+            setGain(currentGainCount);
+            sendRate(INPUT_RATE);
+            sendVFO(frequency);  
         }
         else {
             std::clog << "RTL_TCP_CLIENT: Didn't find the \"RTL0\" magic key." <<
@@ -443,12 +449,6 @@ void CRTL_TCP_Client::receiveAndReconnect()
             if (connected) {
                 std::clog << "RTL_TCP_CLIENT: Successful connected to server " <<
                     std::endl;
-
-                // Always use manual gain, the AGC is implemented in software
-                setGainMode(1);
-                setGain(currentGainCount);
-                sendRate(INPUT_RATE);
-                sendVFO(frequency);
 
                 if (!agcRunning) {
                     agcRunning = true;

--- a/src/welle-cli/welle-cli.cpp
+++ b/src/welle-cli/welle-cli.cpp
@@ -522,6 +522,7 @@ int main(int argc, char **argv)
         in->setAgc(true);
     }
     else {
+        in->setAgc(false);
         in->setGain(options.gain);
     }
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to welle.io, it's highly appreciated!

Please send PRs only against the branch "next".

Describe your PR further using the template provided below.
The more details the better, but please delete unsed sections!
-->

#### What does this PR do and why is it necessary?
It disables software AGC when using manual gain setting.

#### How was it tested? How can it be tested by the reviewer?
Tested with rtl_tcp + passing '-g' parameter (0..28 in case of RTL820T) and observing 'RX gain' in web view.
Both '-g -1' & no '-g' parameter passed enables software AGC again.
