### PR TITLE
feat: Add automated Raspberry Pi build action

### DIFF
--- a/.github/workflows/raspberrypi.yml
+++ b/.github/workflows/raspberrypi.yml
@@ -1,0 +1,49 @@
+name: Raspberry Pi build
+
+on:
+  push:
+    branches:
+      - master
+      - next
+      - 'next*'
+    tags:
+      - 'v*'
+
+jobs:
+  buildx:
+    name: Build with Buildx
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - run: git fetch --prune --unshallow --tags
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/arm/v6
+
+      -
+        name: Build
+        id: build
+        run: |
+          mkdir build/
+          docker build -f Dockerfile.raspberrypi --platform linux/arm/v6 --target export -t build --output . .
+          ls -lah
+
+      - name: Archive artifacts (welle.io build dir)
+        if: always() && steps.build.outcome == 'failure'
+        uses: actions/upload-artifact@v2
+        with:
+          name: welle.io build dir
+          path: build/*
+          if-no-files-found: error

--- a/Dockerfile.raspberrypi
+++ b/Dockerfile.raspberrypi
@@ -1,0 +1,18 @@
+# welle-cli Dockerfile for Raspberry Pi
+
+FROM tianon/raspbian:buster-slim AS build
+RUN apt-get update && apt-get install -y build-essential cmake git qt5-default qtquickcontrols2-5-dev qtdeclarative5-dev \
+    qtmultimedia5-dev libqt5charts5-dev libmp3lame-dev libfftw3-dev \
+    libmpg123-dev libsoapysdr-dev librtlsdr-dev libairspy-dev \
+    libasound2-dev libfaad-dev
+RUN apt-get install -y qml-module-qtquick-controls qml-module-qtquick-controls2 qml-module-qtquick-dialogs
+WORKDIR /src
+RUN git clone https://github.com/AlbrechtL/welle.io.git
+RUN cd welle.io && \
+    mkdir build/ && \
+    cd build && \
+    cmake .. -DRTLSDR=1 -DAIRSPY=1 -DSOAPYSDR=1 && \
+    make -j4
+
+FROM scratch AS export
+COPY --from=build /src/welle.io/build ./build


### PR DESCRIPTION
Added a github action to build Raspberry Pi images with docker buildx

Current state:

- The build works and produces a binary (See: https://github.com/MoJo2600/welle.io/actions/runs/4957542506
- Currently the generated build output is stored as an artifact, but there is no further processing / releasing
- I did not test the binary yet

fixes #781
<!--
Thank you for your interest in contributing to welle.io, it's highly appreciated!

Please send PRs only against the branch "next".

Describe your PR further using the template provided below.
The more details the better, but please delete unsed sections!
-->

#### What does this PR do and why is it necessary?

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
