### PR TITLE
Implement option to specify location of index files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.10)
 
 project(Welle.Io LANGUAGES C CXX)
 
@@ -13,7 +13,7 @@ if(NOT WELLE-IO_VERSION)
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 option(BUILD_WELLE_IO    "Build Welle.io"                        ON  )
 option(BUILD_WELLE_CLI   "Build welle-cli"                       ON  )
@@ -200,8 +200,8 @@ endif()
 
 if (SOAPYSDR)
   find_package(SoapySDR NO_MODULE REQUIRED)
-  # Note: SoapySDRConfig.cmake sets C++11 standard so it needs to be reset to C++14
-  set(CMAKE_CXX_STANDARD 14)
+  # Note: SoapySDRConfig.cmake sets C++11 standard so it needs to be reset to C++17
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 
 include_directories(

--- a/src/welle-cli/webradiointerface.h
+++ b/src/welle-cli/webradiointerface.h
@@ -75,6 +75,7 @@ class WebRadioInterface : public RadioControllerInterface {
         WebRadioInterface(
                 CVirtualInput& in,
                 int port,
+                const std::string& base_dir,
                 DecodeSettings cs,
                 RadioReceiverOptions rro);
         ~WebRadioInterface();
@@ -215,4 +216,6 @@ class WebRadioInterface : public RadioControllerInterface {
             std::chrono::time_point<std::chrono::steady_clock> time_change;
         };
         std::list<ActiveCarouselService> carousel_services_active;
+
+        std::string base_dir;
 };

--- a/src/welle-cli/welle-cli.cpp
+++ b/src/welle-cli/welle-cli.cpp
@@ -275,6 +275,7 @@ class RadioInterface : public RadioControllerInterface {
 struct options_t {
     string soapySDRDriverArgs = "";
     string antenna = "";
+    string base_dir = "";
     int gain = -1;
     string channel = "10B";
     string iqsource = "";
@@ -314,6 +315,7 @@ static void usage()
     endl <<
     "Web server mode:" << endl <<
     "    -w port       Enable web server on port <port>." << endl <<
+    "    -b path       Base directory of index.html and index.js files." << endl <<
     "    -C number     Number of programmes to decode in a carousel" << endl <<
     "                  (to be used with -w, cannot be used with -D)." << endl <<
     "                  This is useful if your machine cannot decode all programmes" << endl <<
@@ -409,10 +411,13 @@ options_t parse_cmdline(int argc, char **argv)
     options.rro.decodeTII = true;
 
     int opt;
-    while ((opt = getopt(argc, argv, "A:c:C:dDf:F:g:hp:O:Ps:Tt:uvw:")) != -1) {
+    while ((opt = getopt(argc, argv, "A:b:c:C:dDf:F:g:hp:O:Ps:Tt:uvw:")) != -1) {
         switch (opt) {
             case 'A':
                 options.antenna = optarg;
+                break;
+            case 'b':
+                options.base_dir = optarg;
                 break;
             case 'c':
                 options.channel = optarg;
@@ -605,7 +610,7 @@ int main(int argc, char **argv)
             return 1;
         }
 
-        WebRadioInterface wri(*in, options.web_port, ds, options.rro);
+        WebRadioInterface wri(*in, options.web_port, options.base_dir, ds, options.rro);
         wri.serve();
     }
     else {


### PR DESCRIPTION
This PR implements an option "-b" for base_dir specifying location of index.html and index.js files for welle-cli web interface. It allows not to have to run the binary in the directory where those files are located.

One can test it to run it from other directory with option like for instance "-b /usr/share/welle-io/html" and the index.html and index.js files from that directory will be used. 

If this option is not specified, the welle-cli behaves like before. One can test it by starting it without that option in a directory that does not have those files and then without that option in a directory that has those files.

This can be useful when debugging and the directory where the files are is read-only and the dumps go to the current directory for instance.