### PR TITLE
Some C++ fixes so that the build is less noisy

### DIFF
--- a/src/backend/fib-processor.cpp
+++ b/src/backend/fib-processor.cpp
@@ -457,14 +457,14 @@ int16_t FIBProcessor::HandleFIG0Extension8(
 
     uint8_t lsFlag  = getBits_1(d, lOffset);
     if (lsFlag == 1) {
-        int16_t SCid = getBits(d, lOffset + 4, 12);
+        /* int16_t SCid = */ getBits(d, lOffset + 4, 12);
         lOffset += 16;
         //           if (findPacketComponent ((SCIds << 4) | SCid) != NULL) {
         //              std::clog << "fib-processor:" << "packet component bestaat !!\n") << std::endl;
         //           }
     }
     else {
-        int16_t SubChId = getBits_6(d, lOffset + 4);
+        /* int16_t SubChId = */ getBits_6(d, lOffset + 4);
         lOffset += 8;
     }
 

--- a/src/input/rtl_tcp.cpp
+++ b/src/input/rtl_tcp.cpp
@@ -515,7 +515,7 @@ void CRTL_TCP_Client::networkBufferCopy()
 
         if(getMyTime() - oldTime_us > 500e3) { // 500 ms
 
-            float bufferFill = (float) sampleNetworkBuffer.GetRingBufferReadAvailable() / sampleNetworkBuffer.GetBufferSize() * 100;
+            // float bufferFill = (float) sampleNetworkBuffer.GetRingBufferReadAvailable() / sampleNetworkBuffer.GetBufferSize() * 100;
             //std::clog << "RTL_TCP_CLIENT: Network buffer fill level " << bufferFill << "%" << std::endl;
 
             oldTime_us = getMyTime();

--- a/src/libs/json.hpp
+++ b/src/libs/json.hpp
@@ -2994,7 +2994,7 @@ scan_number_done:
         std::string result;
         for (const auto c : token_string)
         {
-            if ('\x00' <= c and c <= '\x1F')
+            if ('\x00' <= (signed char)c and c <= '\x1F')
             {
                 // escape control characters
                 std::stringstream ss;

--- a/src/various/channels.cpp
+++ b/src/various/channels.cpp
@@ -226,7 +226,7 @@ string Channels::getChannelNameAtIndex(int index)
 
 std::string Channels::getChannelForFrequency(int frequency)
 {
-    for (const auto c_f : frequencyMap) {
+    for (const auto& c_f : frequencyMap) {
         if (c_f.second == frequency) {
             return c_f.first;
         }

--- a/src/welle-cli/tests.cpp
+++ b/src/welle-cli/tests.cpp
@@ -357,12 +357,12 @@ void Tests::test_multipath(int test_id)
         fprintf(fd, "fname,ofdmthreshold,with_coarse,num_syncs,num_desyncs,time_to_first_sync,frameerrors,aacerrors,rserrors\n");
     }
 
-    fprintf(fd, "%s,%s,%d,%zu,%zu,%ld,%d,%d,%d\n",
+    fprintf(fd, "%s,%s,%d,%zu,%zu,%lld,%d,%d,%d\n",
             intf.getFileName().c_str(),
             fftPlacementMethodToString(rro.fftPlacementMethod),
             rro.disableCoarseCorrector ? 0 : 1,
             ri.num_syncs, ri.num_desyncs,
-            chrono::duration_cast<chrono::milliseconds>(start_time-ri.first_sync_time).count(),
+            static_cast<long long>(chrono::duration_cast<chrono::milliseconds>(start_time-ri.first_sync_time).count()),
             std::accumulate(tph.frameErrorStats.begin(), tph.frameErrorStats.end(), 0),
             std::accumulate(tph.aacErrorStats.begin(), tph.aacErrorStats.end(), 0),
             std::accumulate(tph.rsErrorStats.begin(), tph.rsErrorStats.end(), 0));

--- a/src/welle-cli/tests.cpp
+++ b/src/welle-cli/tests.cpp
@@ -260,7 +260,7 @@ void Tests::test_with_noise_iteration(double stddev)
     while (not service_selected) {
         this_thread::sleep_for(chrono::seconds(1));
 
-        for (const auto s : rx.getServiceList()) {
+        for (const auto& s : rx.getServiceList()) {
             if (rx.playSingleProgramme(tph, dumpFileName, s) == false) {
                 cerr << "Tune to " << s.serviceLabel.utf8_label() << " failed" << endl;
             }
@@ -330,7 +330,7 @@ void Tests::test_multipath(int test_id)
     while (not service_selected) {
         this_thread::sleep_for(chrono::seconds(1));
 
-        for (const auto s : rx.getServiceList()) {
+        for (const auto& s : rx.getServiceList()) {
             if (rx.playSingleProgramme(tph, dumpFileName, s) == false) {
                 cerr << "Tune to " << s.serviceLabel.utf8_label() << " failed" << endl;
             }

--- a/src/welle-cli/webprogrammehandler.cpp
+++ b/src/welle-cli/webprogrammehandler.cpp
@@ -80,7 +80,7 @@ class FlacEncoder : protected FLAC::Encoder::Stream, public IEncoder
         return FLAC::Encoder::Stream::process_interleaved(pcm_32.data(), pcm_32.size()/channels);
     }
 
-    FLAC__StreamEncoderWriteStatus write_callback(const FLAC__byte buffer[], size_t bytes, uint32_t samples, uint32_t current_frame) override
+    FLAC__StreamEncoderWriteStatus write_callback(const FLAC__byte buffer[], size_t bytes, uint32_t /* samples */, uint32_t /* current_frame */) override
     {
         if (!streamHeaderInitialised)
         {

--- a/src/welle-cli/welle-cli.cpp
+++ b/src/welle-cli/welle-cli.cpp
@@ -700,7 +700,7 @@ int main(int argc, char **argv)
                 }
 
                 bool service_selected = false;
-                for (const auto s : rx.getServiceList()) {
+                for (const auto& s : rx.getServiceList()) {
                     if (s.serviceLabel.utf8_label().find(service_to_tune) != string::npos) {
                         service_selected = true;
                         string dumpFileName;

--- a/src/welle-gui/mpris/mpris.cpp
+++ b/src/welle-gui/mpris/mpris.cpp
@@ -169,7 +169,7 @@ bool Mpris::canSeek() const { return false; }
 
 QString Mpris::loopStatus() const { return "None"; }
 
-void Mpris::setLoopStatus(const QString &value) {}
+void Mpris::setLoopStatus(const QString & /* value */) {}
 
 double Mpris::maximumRate() const { return 1.0; }
 
@@ -197,7 +197,7 @@ void Mpris::volumeChanged(qreal volume)
     EmitNotification("Volume", volume);
 }
 
-void Mpris::motChanged(QString pictureName, QString categoryTitle, int categoryId, int slideId)
+void Mpris::motChanged(QString pictureName, QString /* categoryTitle */, int /* categoryId */, int /* slideId */)
 {
     //qDebug() << "MPRIS: pictureName: " << pictureName;
 
@@ -252,11 +252,11 @@ qlonglong Mpris::position() const { return 0; }
 
 double Mpris::rate() const { return 1.0; }
 
-void Mpris::setRate(double value) {}
+void Mpris::setRate(double /* value */) {}
 
 bool Mpris::shuffle() const { return false; }
 
-void Mpris::setShuffle(bool value) {}
+void Mpris::setShuffle(bool /* value */) {}
 
 double Mpris::volume() const { return (double) qvariant_cast< qreal >(radioController->property("volume")); }
 
@@ -274,7 +274,7 @@ void Mpris::Next()
         radioController->play(autoChannel, title, autoService);
 }
 
-void Mpris::OpenUri(const QString &Uri) {}
+void Mpris::OpenUri(const QString & /* Uri */) {}
 
 void Mpris::Pause() { Stop(); }
 
@@ -306,9 +306,9 @@ void Mpris::Previous()
         radioController->play(autoChannel, title, autoService);
 }
 
-void Mpris::Seek(qlonglong Offset) {}
+void Mpris::Seek(qlonglong /* Offset */) {}
 
-void Mpris::SetPosition(const QDBusObjectPath &TrackId, qlonglong Position) {}
+void Mpris::SetPosition(const QDBusObjectPath & /* TrackId */, qlonglong /* Position */) {}
 
 void Mpris::Stop() { radioController->stop(); }
 

--- a/src/welle-gui/radio_controller.cpp
+++ b/src/welle-gui/radio_controller.cpp
@@ -34,6 +34,7 @@
 #include <QDebug>
 #include <QSettings>
 #include <QStandardPaths>
+#include <QTimeZone>
 #include <stdexcept>
 
 #include "radio_controller.h"
@@ -610,7 +611,7 @@ std::vector<DSPCOMPLEX> CRadioController::getConstellationPoint()
  ********************/
 void CRadioController::initialise(void)
 {
-    for (const auto param_value : deviceParametersString) {
+    for (const auto& param_value : deviceParametersString) {
         device->setDeviceParam(param_value.first, param_value.second);
     }
 
@@ -890,8 +891,7 @@ void CRadioController::displayDateTime(const dab_date_time_t& dateTime)
 
     int OffsetFromUtc = dateTime.hourOffset * 3600 +
                         dateTime.minuteOffset * 60;
-    currentDateTime.setOffsetFromUtc(OffsetFromUtc);
-    currentDateTime.setTimeSpec(Qt::OffsetFromUTC);
+    currentDateTime.setTimeZone(QTimeZone(OffsetFromUtc));
 
     emit dateTimeChanged(currentDateTime);
 }


### PR DESCRIPTION
There are some superfluous std:: in a file where the using namespace std is already stated.
There are some unused variables and iterating using copies of object that were changed to const references
There is one deprecated function that will be removed in QT 6.9, so I changed it to something that works well with older QT too, but that will continue to work with 6.9 too.

I had this idea of shared library between the welle-io and welle-cli that would eventually allow hooking to the welle another interface. I am planning to work on one that would work on LCD and small OLED displays. I have some proof-of concept code, but first, I would like to know whether this is not something that will meet hard opposition before I get deep into it.