### PR TITLE
build(cmake): Correct .desktop and appdata after moving to flatpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,8 +444,8 @@ if(BUILD_WELLE_IO)
         INSTALL (FILES src/welle-gui/doc/man/welle-io.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
 
         if(UNIX AND NOT APPLE)
-            INSTALL (FILES ${PROJECT_SOURCE_DIR}/welle-io.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
-            INSTALL (FILES ${PROJECT_SOURCE_DIR}/io.welle.welle_io.metainfo.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
+            INSTALL (FILES ${PROJECT_SOURCE_DIR}/io.welle.welle_io.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
+            INSTALL (FILES ${PROJECT_SOURCE_DIR}/io.welle.welle_io.appdata.xml DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/metainfo)
 
             INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icons/16x16/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps)
             INSTALL (FILES ${PROJECT_SOURCE_DIR}/src/welle-gui/icons/24x24/welle-io.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/24x24/apps)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to welle.io, it's highly appreciated!

Please send PRs only against the branch "next".

Describe your PR further using the template provided below.
The more details the better, but please delete unsed sections!
-->

#### What does this PR do and why is it necessary?
Building with cmake no longer works because these files have been renamed in 9d95a3113c8d6881160721037fa186184b6dff84.

#### Any background context you want to provide?
Noticed this while upgrading build to 2.6 on Arch Linux AUR: [welle.io](https://aur.archlinux.org/packages/welle.io) where it is already [patched](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=welle.io#n20) in the build process.

