### PR TITLE
Fix missing xxd in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # welle-cli Dockerfile
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 LABEL maintainer "albrechtloh@gmx.de"
 LABEL description "welle-cli Docker image"
 
 RUN apt-get update -y && \
-apt-get install -y git build-essential cmake plocate libfaad-dev libmpg123-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev libairspy-dev libmp3lame-dev
+apt-get install -y git build-essential cmake plocate libfaad-dev libmpg123-dev libfftw3-dev librtlsdr-dev libusb-1.0-0-dev mesa-common-dev libglu1-mesa-dev libpulse-dev libsoapysdr-dev libairspy-dev libmp3lame-dev xxd
 
 RUN  git clone https://github.com/AlbrechtL/welle.io.git && \
 cd welle.io && \


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Builder in Dockerfile was missing xxd binary to be successfully executed. 

#### Further notes

Ubuntu had to be upgraded as only recent version of xxd has '-n' flag available.