### PR TITLE
Bump CMake minimum to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.16)
 
 project(Welle.Io LANGUAGES C CXX)
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to welle.io, it's highly appreciated!

Please send PRs only against the branch "next".

Describe your PR further using the template provided below.
The more details the better, but please delete unsed sections!
-->

#### What does this PR do and why is it necessary?
This PR bumps `cmake_minimum_required` from very old 3.2 to much newer 3.16. 
This is required to make welle.io build-able with [CMake 4.0] that is currently used by Arch Linux. And this is also required minimum version for [Qt6 projects]

[CMake 4.0]: https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features
[Qt6 projects]: https://doc.qt.io/qt-6/cmake-supported-cmake-versions.html

#### How was it tested? How can it be tested by the reviewer?
I did a normal cmake build and it seems to work fine. CMake 3.16 came out in 2019 so it should be old enough target to also work on older distributions.

    cmake -S . -B build -G Ninja
    cmake --build build

#### Any background context you want to provide?
I noticed this problem during [welle.io Arch Linux AUR]  package build failing with:

[welle.io Arch Linux AUR]: https://aur.archlinux.org/packages/welle.io

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
```


#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
