### PR TITLE
Allow specifying other PCM device then default in the welle-cli

### DIFF
--- a/src/welle-cli/alsa-output.cpp
+++ b/src/welle-cli/alsa-output.cpp
@@ -118,12 +118,10 @@ void AlsaOutput::playPCM(std::vector<int16_t>&& pcm)
 
         snd_pcm_sframes_t ret = snd_pcm_writei(pcm_handle, data, frames_to_send);
 
-        if (ret == -EPIPE) {
-            snd_pcm_recover(pcm_handle, ret, 0);
-            fprintf(stderr, "XRUN\n");
-            break;
+        if (ret < 0) {
+            ret = snd_pcm_recover(pcm_handle, ret, 0);
         }
-        else if (ret < 0) {
+        if (ret < 0) {
             fprintf(stderr, "ERROR: Can't write to PCM device. %s\n",
                     snd_strerror(ret));
             break;

--- a/src/welle-cli/alsa-output.cpp
+++ b/src/welle-cli/alsa-output.cpp
@@ -29,12 +29,14 @@
 #include "welle-cli/alsa-output.h"
 
 using namespace std;
-#define PCM_DEVICE "default"
 
 AlsaOutput::AlsaOutput(int chans, unsigned int rate) :
+    AlsaOutput(PCM_DEVICE, chans, rate) {}
+
+AlsaOutput::AlsaOutput(const char* device, int chans, unsigned int rate) :
     channels(chans)
 {
-    int err = snd_pcm_open(&pcm_handle, PCM_DEVICE, SND_PCM_STREAM_PLAYBACK, 0);
+    int err = snd_pcm_open(&pcm_handle, device, SND_PCM_STREAM_PLAYBACK, 0);
     if (err < 0) {
         fprintf(stderr, "ERROR: Can't open \"%s\" PCM device. %s\n",
                 PCM_DEVICE, snd_strerror(err));
@@ -117,9 +119,8 @@ void AlsaOutput::playPCM(std::vector<int16_t>&& pcm)
         snd_pcm_sframes_t ret = snd_pcm_writei(pcm_handle, data, frames_to_send);
 
         if (ret == -EPIPE) {
-            snd_pcm_prepare(pcm_handle);
+            snd_pcm_recover(pcm_handle, ret, 0);
             fprintf(stderr, "XRUN\n");
-            this_thread::sleep_for(chrono::milliseconds(20));
             break;
         }
         else if (ret < 0) {

--- a/src/welle-cli/alsa-output.h
+++ b/src/welle-cli/alsa-output.h
@@ -31,6 +31,7 @@
 
 class AlsaOutput {
     public:
+        AlsaOutput(const char* device, int chans, unsigned int rate);
         AlsaOutput(int chans, unsigned int rate);
         ~AlsaOutput();
         AlsaOutput(const AlsaOutput& other) = delete;


### PR DESCRIPTION
With some sound cards that don't have hardware volume control, software volume control can be achieved in alsa config file. However, this creates an additional PCM device. The new "-o" option allows us to output into this device instead of to default.
I chose the "-o" option as that was the only reasonable option available. In alsa tools, this device is normally referred to using the option "-D", but that option is already taken in welle-cli