### PR TITLE
Library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,14 +360,54 @@ add_definitions("-DCURRENT_VERSION=\"${CURRENT_VERSION}\"")
 STRING(TIMESTAMP BUILD_DATE "%s" UTC)
 add_definitions("-DBUILD_DATE=\"${BUILD_DATE}\"")
 
+add_library(welle STATIC
+#add_library(welle SHARED
+    ${backend_sources}
+    ${faad_sources}
+    ${fft_sources}
+    ${input_sources}
+    ${mpg123_sources}
+)
+
+string(REGEX MATCHALL
+    "([0-9]+)"
+    LIB_MATCH
+    "${CURRENT_VERSION}"
+)
+
+list(POP_FRONT LIB_MATCH LIB_MATCH_1)
+list(POP_FRONT LIB_MATCH LIB_MATCH_2)
+if (NOT LIB_MATCH STREQUAL "")
+    list(POP_FRONT LIB_MATCH LIB_MATCH_3)
+else ()
+    set(LIB_MATCH_3 0)
+endif ()
+
+set_property(TARGET welle PROPERTY VERSION "${LIB_MATCH_1}.${LIB_MATCH_2}.${LIB_MATCH_3}")
+set_property(TARGET welle PROPERTY SOVERSION "${LIB_MATCH_1}")
+set_property(TARGET welle PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+target_link_libraries(welle PRIVATE
+      ${LIBRTLSDR_LIBRARIES}
+      ${LIBAIRSPY_LIBRARIES}
+      ${FFTW3F_LIBRARIES}
+      ${AAC_LIBRARIES}
+      ${SoapySDR_LIBRARIES}
+      ${MPG123_LIBRARIES}
+)
+
+#install(TARGETS welle
+#    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#)
+
 if(BUILD_WELLE_IO)
     set(executableName welle-io)
 
     if(CMAKE_AUTORCC)
-        qt_add_executable (${executableName} MANUAL_FINALIZATION ${welle_io_sources} ${backend_sources} ${input_sources} ${fft_sources} ${mpg123_sources} ${faad_sources} ${EXTRA_MOCS} src/welle-gui/resources.qrc)
+        qt_add_executable (${executableName} MANUAL_FINALIZATION ${welle_io_sources} ${EXTRA_MOCS} src/welle-gui/resources.qrc)
     else()
         qt_add_resources(welle_io_sources src/welle-gui/resources.qrc)
-        qt_add_executable (${executableName} MANUAL_FINALIZATION ${welle_io_sources} ${backend_sources} ${input_sources} ${fft_sources} ${mpg123_sources} ${faad_sources} ${EXTRA_MOCS})
+        qt_add_executable (${executableName} MANUAL_FINALIZATION ${welle_io_sources} ${EXTRA_MOCS})
     endif()
 
     if(ANDROID)
@@ -428,12 +468,7 @@ if(BUILD_WELLE_IO)
     endif()
 
     target_link_libraries (${executableName} PRIVATE
-      ${LIBRTLSDR_LIBRARIES}
-      ${LIBAIRSPY_LIBRARIES}
-      ${FFTW3F_LIBRARIES}
-      ${AAC_LIBRARIES}
-      ${SoapySDR_LIBRARIES}
-      ${MPG123_LIBRARIES}
+      welle
       Threads::Threads
       Qt6::Core Qt6::Widgets Qt6::Multimedia Qt6::Charts Qt6::Qml Qt6::Quick Qt6::QuickControls2
     )
@@ -476,9 +511,6 @@ if(BUILD_WELLE_CLI AND NOT ANDROID)
     set(cliExecutableName welle-cli)
     add_executable (${cliExecutableName}
         ${welle_cli_sources}
-        ${backend_sources}
-        ${input_sources}
-        ${fft_sources}
         index.html.h
         index.js.h
         favicon.ico.h)
@@ -489,14 +521,9 @@ if(BUILD_WELLE_CLI AND NOT ANDROID)
     endif(CMAKE_BUILD_TYPE MATCHES Debug)
 
     target_link_libraries (${cliExecutableName}
-      ${LIBRTLSDR_LIBRARIES}
-      ${LIBAIRSPY_LIBRARIES}
-      ${FFTW3F_LIBRARIES}
-      ${AAC_LIBRARIES}
+      welle
       ${ALSA_LIBRARIES}
       ${LAME_LIBRARIES}
-      ${SoapySDR_LIBRARIES}
-      ${MPG123_LIBRARIES}
       ${FLACPP_LIBRARIES}
       Threads::Threads
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 option(BUILD_WELLE_IO    "Build Welle.io"                        ON  )
 option(BUILD_WELLE_CLI   "Build welle-cli"                       ON  )
+option(LIBWELLE_STATIC   "Build the welle library as static"     ON  )
 option(WITH_APP_BUNDLE   "Enable Application Bundle for macOS"   ON  )
 option(KISS_FFT          "KISS FFT instead of FFTW"              OFF )
 option(PROFILING         "Enable profiling (see README.md)"      OFF )
@@ -360,8 +361,13 @@ add_definitions("-DCURRENT_VERSION=\"${CURRENT_VERSION}\"")
 STRING(TIMESTAMP BUILD_DATE "%s" UTC)
 add_definitions("-DBUILD_DATE=\"${BUILD_DATE}\"")
 
-add_library(welle STATIC
-#add_library(welle SHARED
+if (LIBWELLE_STATIC)
+  set(STATIC_OR_SHARED STATIC)
+else ()
+  set(STATIC_OR_SHARED SHARED)
+endif()
+
+add_library(welle ${STATIC_OR_SHARED}
     ${backend_sources}
     ${faad_sources}
     ${fft_sources}
@@ -396,9 +402,11 @@ target_link_libraries(welle PRIVATE
       ${MPG123_LIBRARIES}
 )
 
-#install(TARGETS welle
-#    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-#)
+if (NOT LIBWELLE_STATIC)
+install(TARGETS welle
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+endif()
 
 if(BUILD_WELLE_IO)
     set(executableName welle-io)


### PR DESCRIPTION
Another attempt at this one.

I am running that personally for some time and I can attest that the default situation, when the common object files are first compiled into a static library and then that library is *statically* linked with the welle-io and welle-cli tools, all works just like currently. The result are those two binaries and nothing else.

The advantage is that in this situation, the source files that are part of that library and that were previously common to both executables, are built only once whereas currently they are built twice.

As for the shared library, It is only if requested explicitly, the shared library can be built and installed. But for this, the user has to require it with setting the option LIBWELLE_STATIC to OFF.