### PR TITLE
Add url to playlist

### DIFF
--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -402,7 +402,10 @@ static string trim(const string& str) {
 
 static string get_base_uri(const map<string,string>& headers) {
     if (headers.find("Referer") != headers.end()) {
-        return headers.at("Referer");
+        string referer = headers.at("Referer");
+        if (referer.back() != '/')
+            referer += '/';
+        return referer;
     } else if (headers.find("Host") != headers.end()) {
         return "http://" + headers.at("Host") + "/";
     } else {

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -363,12 +363,18 @@ static vector<char> recv_exactly(Socket& s, size_t num_bytes)
     return buf;
 }
 
-static vector<string> split(const string& str, char c = ' ')
+static vector<string> split(const string& str, char c = ' ', size_t max_splits = string::npos)
 {
     const char *s = str.data();
     vector<string> result;
     do {
         const char *begin = s;
+
+        if (result.size() >= max_splits) {
+            result.push_back(s);
+            break;
+        }
+
         while (*s != c && *s)
             s++;
         result.push_back(string(begin, s));
@@ -386,6 +392,23 @@ struct http_request_t {
     string post_data;
 };
 
+static string trim(const string& str) {
+    auto start = str.begin();
+    while (start != str.end() && isspace(*start)) ++start;
+    auto end = str.end();
+    do { --end; } while (end != start && isspace(*end));
+    return string(start, end + 1);
+}
+
+static string get_base_uri(const map<string,string>& headers) {
+    if (headers.find("Referer") != headers.end()) {
+        return headers.at("Referer");
+    } else if (headers.find("Host") != headers.end()) {
+        return "http://" + headers.at("Host") + "/";
+    } else {
+        return "/";
+    }
+}
 
 static http_request_t parse_http_headers(Socket& s) {
     http_request_t r;
@@ -416,10 +439,10 @@ static http_request_t parse_http_headers(Socket& s) {
             break;
         }
 
-        const auto header = split(header_line, ':');
+        const auto header = split(header_line, ':', 1);
 
         if (header.size() == 2) {
-            r.headers.emplace(header[0], header[1]);
+            r.headers.emplace(header[0], trim(header[1]));
         }
     }
 
@@ -482,7 +505,7 @@ bool WebRadioInterface::dispatch_client(Socket&& client)
                 success = send_mux_json(s);
             }
             else if (req.url == "/mux.m3u") {
-                success = send_mux_playlist(s);
+                success = send_mux_playlist(s, get_base_uri(req.headers));
             }
             else if (req.url == "/fic") {
                 success = send_fic(s);
@@ -818,7 +841,7 @@ bool WebRadioInterface::send_mux_json(Socket& s)
     return true;
 }
 
-bool WebRadioInterface::send_mux_playlist(Socket& s)
+bool WebRadioInterface::send_mux_playlist(Socket& s, string base_uri)
 {
     stringstream m3u;
     m3u << "#EXTM3U\n";
@@ -837,7 +860,7 @@ bool WebRadioInterface::send_mux_playlist(Socket& s)
                     case TransportMode::Audio:
                         if (sc.audioType() == AudioServiceComponentType::DAB or
                             sc.audioType() == AudioServiceComponentType::DABPlus) {
-                            url_mp3 = "/mp3/" + hex_sid;
+                            url_mp3 = base_uri + "mp3/" + hex_sid;
                         }
                         break;
                     default:

--- a/src/welle-cli/webradiointerface.h
+++ b/src/welle-cli/webradiointerface.h
@@ -114,7 +114,7 @@ class WebRadioInterface : public RadioControllerInterface {
         bool send_mux_json(Socket& s);
 
         // Generate and send a m3u playlist with all services
-        bool send_mux_playlist(Socket& s);
+        bool send_mux_playlist(Socket& s, std::string base_uri);
 
         // Send a stream containing the selected programme.
         // stream is a service id, either in hex with 0x prefix or


### PR DESCRIPTION
Use the Referer or Host header to add URL to the items in the m3u playlist.

Add argument max_splits, to allow splitting headers that also include colon in the value, and trim the header values from leading/trailing whitespace.

<!--
Thank you for your interest in contributing to welle.io, it's highly appreciated!

Please send PRs only against the branch "next".

Describe your PR further using the template provided below.
The more details the better, but please delete unsed sections!
-->

#### What does this PR do and why is it necessary?
When downloading the m3u playlist from the webserver started with welle-cli, the links in the playlist are e.g. "/mp3/0x605f". This playlist file can't be used directly in VLC. This PR updates those links to a full link, e.g. http://my.server.local:8888/mp3/0x605f. It uses the Referer or Host header. If neither exist, nothing changes, the playlist still contains e.g. "/mp3/0x605f".

#### How was it tested? How can it be tested by the reviewer?
I've tested it by downloading the m3u playlist through the web interface, opening the playlist file in VLC and playing the streams.

#### What are the relevant tickets if any?
#779
#659