### PR TITLE
Specify the Flatpak libdir for SoapySDR modules

### DIFF
--- a/io.welle.welle-gui.yml
+++ b/io.welle.welle-gui.yml
@@ -76,6 +76,7 @@ modules:
   - name: SoapyHackRF
     buildsystem: cmake-ninja
     config-opts:
+      - '-DCMAKE_INSTALL_LIBDIR=lib'
       - '-Wno-dev'
     sources:
       - type: git
@@ -85,6 +86,7 @@ modules:
   - name: SoapyRemote
     buildsystem: cmake-ninja
     config-opts:
+      - '-DCMAKE_INSTALL_LIBDIR=lib'
       - '-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
       - '-Wno-dev'
     sources:


### PR DESCRIPTION
These modules are also installed into `/app/lib64` by default.