### PR TITLE
Fixed definitions if QT_NO_SYSTEMTRAYICON is defined in gui_helper

### DIFF
--- a/src/welle-gui/gui_helper.cpp
+++ b/src/welle-gui/gui_helper.cpp
@@ -259,13 +259,13 @@ void CGUIHelper::showInfoMessage(QString Text)
 #endif
 }
 
+#ifndef QT_NO_SYSTEMTRAYICON
 void CGUIHelper::showWindow(QSystemTrayIcon::ActivationReason r)
 {
-#ifndef QT_NO_SYSTEMTRAYICON
     if (r == QSystemTrayIcon::Trigger)
         emit restoreWindow();
-#endif
 }
+#endif
 
 void CGUIHelper::registerSpectrumSeries(QAbstractSeries* series)
 {

--- a/src/welle-gui/gui_helper.h
+++ b/src/welle-gui/gui_helper.h
@@ -164,7 +164,9 @@ private slots:
     void motReset();
     void showErrorMessage(QString Text);
     void showInfoMessage(QString Text);
+#ifndef QT_NO_SYSTEMTRAYICON
     void showWindow(QSystemTrayIcon::ActivationReason r);
+#endif
 
 signals:
     void foundChannelCount(int channelCount);


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
When compiling with `QT_NO_SYSTEMTRAYICON `defined, `QSystemTrayIcon` is no longer included.
Function prototypes that reference `QSystemTrayIcon` should not be defined.
This PR ensures in gui_helper.h and gui_helper.cpp any references to `QSystemTrayIcon` are wrapped in a
`#ifndef QT_NO_SYSTEMTRAYICON ` directive

#### How was it tested? How can it be tested by the reviewer?
Compile as normal with `QT_NO_SYSTEMTRAYICON `defined

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
