### PR TITLE
Fix start stop and volume buttons

### DIFF
--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -169,7 +169,7 @@ ApplicationWindow {
                 Accessible.role: Accessible.Button
                 Accessible.name: (radioController.isPlaying || radioController.isChannelScan) ? qsTr("Stop") : qsTr("Play")
                 Accessible.description: radioController.isPlaying ? qsTr("Stop playback") : radioController.isChannelScan ? qsTr("Stop scan") : qsTr("Start playback")
-                Accessible.onPressAction: startStopIconMouseArea.clicked(mouse)
+                Accessible.onPressAction: startStopIcon.clicked()
 
                 WToolTip {
                     text: (radioController.isPlaying || radioController.isChannelScan) ? qsTr("Stop") : qsTr("Play")
@@ -182,7 +182,7 @@ ApplicationWindow {
                     context: Qt.ApplicationShortcut
                     autoRepeat: false
                     sequences: ["Media Pause", "Toggle Media Play/Pause", "S"]
-                    onActivated: startStopIconMouseArea.clicked(0)
+                    onActivated: startStopIcon.clicked()
                 }
                 Shortcut {
                     context: Qt.ApplicationShortcut

--- a/src/welle-gui/QML/MainView.qml
+++ b/src/welle-gui/QML/MainView.qml
@@ -156,6 +156,7 @@ ApplicationWindow {
                 id: startStopIcon
                 implicitWidth: icon.width + Units.dp(20)
                 icon.name: "stop"
+                hoverEnabled: true
 
                 onClicked: {
                     if (radioController.isPlaying || radioController.isChannelScan) {
@@ -232,6 +233,7 @@ ApplicationWindow {
                 id: speakerIconContainer
                 implicitWidth: icon.width + Units.dp(24)
                 icon.name: "speaker"
+                hoverEnabled: true
 
                 onPressAndHold: volumePopup.open()
                 onClicked: {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR fixes two small bugs that I noticed when I compiled and used welle-io on my Raspberry
Pi 5 Desktop (Raspberry Pi OS trixie aarch64).

These bugs are:
1. The tooltips of both, the start/stop and the volume button are missing. (see first commit)
2. There are two dangling references to startStopIconMouseArea that prevent start/stop button
   from being triggered by keyboard shortcuts and Accessible (e.g. a screen reader). This is due to
   a change started in Version v2.5, that has not been put through, completely. (see second commit)

#### How was it tested? How can it be tested by the reviewer?
I compiled and started welle-io by:
```welle.io/build $ cmake -DRTLSDR=ON .. && make && ./welle-io```
first on branch next, and then on the branch of this PR.

I already got DAB channels scanned and stored in $HOME/.config/welle.io with my /usr/bin/welle-io,
Version 2.4 from the trixie Debian package, that I had been using before.
So these channels were shown and could be selected by both of my builds.

- The tooltips were tested by hovering over the start/stop button and volume button, respectively.
- The keyboard shortcuts were tested by pressing "S" on my keyboard, several times.

On branch next, welle.io had no tooltips appearing for the two buttons and pressing "S" did not
start or stop playing, but produced a warning message in the log output:
"qrc:/QML/MainView.qml:184: ReferenceError: startStopIconMouseArea is not defined".

On my branch fix-start-stop-and-volume-buttons, the tooltips appeared and "S" toggled start/stop.
There was no warning or error message on log output.

- The Accessible part has not been tested, yet. I tried with the screen reader "orca", which
  is recommended for my OS. By pressing TAB, repeatedly, I could make orca read out the
  different Accessible.names of the buttons and lists on the welle-io window,
  especially it said "stop", when the stop button was visible.
  Staying on that button with the focus and toggling with "S" made orca say "play" and "stop",
  alternatingly, in alignment with the button's current function.

But, I could not figure out how to make orca trigger any action or mouse press.
So, the Accessible feature seems to work properly, essentially.
But I could not test the Accessible.onPressAction.

What I did, was, I checked, that ToolButton.clicked() takes no argument in Qt 6.5, 6.8, 6.11, 
nor does Accessible.onPressAction().
So, I adapted the code according to the keyboard shortcut.

I think, if the Accessible worked in version 2.4 with startStopIconMouseArea.clicked(mouse),
then it should work with startStopIcon.clicked(), as well, because the keyboard shortcut got
the same change and is working properly, with my fix.

I hope, you can test that?

Or tell me, how to test.

#### Any background context you want to provide?

Firstly, I would like to mention that these problems were introduced in Version v2.5, most likely
with the commit c77614e3b1285ab1444852761181755de0671327 and have never been fixed since then.

Secondly, I want to give feedback about, what I experienced, when compiling welle-io, because I
think it could be helpful for others.

I did a long detailed debugging session with duck.ai to figure out, that there was no problem,
where I initially thought to be one:

I compiled on Raspberry Pi OS (trixie) 64 bit, with cmake/make and trixies QT 6.8.2 debian
packages.
After having installed all dependencies, running cmake produced 38 warnings about 38 qml plugins,
that it could not find. They looked like:
```
CMake Warning at /usr/lib/aarch64-linux-gnu/cmake/Qt6Qml/Qt6QmlMacros.cmake:4216 (message):
  The qml plugin 'qtquick2plugin' is a dependency of 'welle-io', but the link
  target it defines (Qt6::qtquick2plugin) does not exist in the current
  scope.  The plugin will not be linked.
```
They are produced by the Qt/cmake-Makro `qt6_import_qml_plugins`, which is supposed to do
nothing on non-static Qt builds, what I use.

Nevertheless, the executable could be built without any warning or error.

I started welle-io with the environment variable `QT_DEBUG_PLUGINS=1` set and checked the qml plugin
names on the debug output. Most of the plugins of the warning list were said to be loaded,
no plugin was mentioned as "could not load!".
And welle-io works as expected.

So, these warning can safely be ignored!

#### What are the relevant tickets if any?

I searched in the issue list, but could not find any matching issue.

#### Further notes

I love welle-io. I've ben using it nearly every day, for four years now beginning with Raspi 3B,
now Pi 4 and 5.
I really appreciate the work you've done. It's a great tool for RTLSDR! Thank you!

As a last note I want to make you aware, that there also is one dangling reference to a MouseArea
in MainView.qml, which I did not know how to fix for the new style of the volume slider.

It's in [MainView.qml:250](https://github.com/AlbrechtL/welle.io/blob/next/src/welle-gui/QML/MainView.qml#L250):
```
Accessible.onPressAction: speakerIconMouseArea.clicked(mouse)
```
I guess, you have to do a similar change like i did to the start/stop button.