### PR TITLE
Fix socket/thread leaks and SIGABRT crashes in welle-cli HTTP server

### DIFF
--- a/src/various/Socket.cpp
+++ b/src/various/Socket.cpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <cstring>
 #include "various/Socket.h"
+#include <netinet/tcp.h>
 
 #if defined(_WIN32)
 class SocketInitialiseWrapper {
@@ -173,6 +174,24 @@ Socket Socket::accept()
         perror("accept failed");
         return {};
     }
+
+    // Enable TCP keepalive to detect dead connections.
+    // Without this, CLOSE_WAIT sockets accumulate over days and
+    // eventually exhaust the file descriptor limit.
+    int keepalive = 1;
+    if (setsockopt(conn, SOL_SOCKET, SO_KEEPALIVE,
+                &keepalive, sizeof(keepalive)) == -1) {
+        perror("setsockopt(SO_KEEPALIVE)");
+    }
+#if !defined(_WIN32)
+    // Aggressive timing: detect dead peers in ~90s instead of ~2h default
+    int idle = 60;   // idle seconds before first probe
+    int intvl = 10;  // seconds between probes
+    int cnt = 3;     // failed probes before declaring connection dead
+    setsockopt(conn, IPPROTO_TCP, TCP_KEEPIDLE,  &idle,  sizeof(idle));
+    setsockopt(conn, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+    setsockopt(conn, IPPROTO_TCP, TCP_KEEPCNT,   &cnt,   sizeof(cnt));
+#endif
 
     Socket s;
     s.sock = conn;

--- a/src/various/Socket.h
+++ b/src/various/Socket.h
@@ -76,6 +76,9 @@ class Socket {
         bool connect(const std::string& address, int port, int timeout);
 
         ssize_t recv(void *buffer, size_t length, int flags);
+
+        // Expose native fd for select/poll/epoll
+        int native_handle() const { return sock; }
         ssize_t send(const void *buffer, size_t length, int flags);
 
     private:

--- a/src/welle-cli/webprogrammehandler.cpp
+++ b/src/welle-cli/webprogrammehandler.cpp
@@ -200,10 +200,27 @@ bool ProgrammeSender::send_stream(const std::vector<uint8_t>& headerdata, const 
     return true;
 }
 
-void ProgrammeSender::wait_for_termination() const
+void ProgrammeSender::wait_for_termination()
 {
     std::unique_lock<std::mutex> lock(mutex);
     while (running) {
+        // Drain the socket to detect a disconnected peer.
+        // MSG_PEEK was unreliable: if leftover data (e.g. leftover
+        // HTTP bytes) stayed in the receive buffer, recv(MSG_PEEK)
+        // returned the data length instead of 0 even after the peer
+        // sent FIN. We now drain any stale data into a discard buffer
+        // until recv() returns 0 (peer disconnected) or EAGAIN.
+        if (s.valid()) {
+            char buf[256];
+            ssize_t r = s.recv(buf, sizeof(buf), MSG_DONTWAIT);
+            if (r == 0) {
+                // Peer performed orderly shutdown (FIN received, all data consumed)
+                const_cast<ProgrammeSender*>(this)->cancel();
+                break;
+            }
+            // r > 0: stale data drained, will check again next cycle
+            // r < 0 (EAGAIN): no data, keep waiting
+        }
         cv.wait_for(lock, chrono::seconds(2));
     }
 }

--- a/src/welle-cli/webprogrammehandler.h
+++ b/src/welle-cli/webprogrammehandler.h
@@ -49,7 +49,7 @@ class ProgrammeSender {
         ProgrammeSender(ProgrammeSender&& other);
         ProgrammeSender& operator=(ProgrammeSender&& other);
         bool send_stream(const std::vector<uint8_t>& headerdata, const std::vector<uint8_t>& mp3data);
-        void wait_for_termination() const;
+        void wait_for_termination();
         void cancel();
 };
 

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -33,6 +33,7 @@
 #include <ctime>
 #include <errno.h>
 #include <future>
+#include <sys/select.h>
 #include <iomanip>
 #include <iostream>
 #include <regex>
@@ -1419,17 +1420,50 @@ void WebRadioInterface::serve()
     }
 #endif
 
+    const int server_fd = serverSocket.native_handle();
+
     while (sig_caught == 0) {
-        auto client = serverSocket.accept();
+        // Use select() with a 1-second timeout so we periodically
+        // clean up completed futures even when no new connections
+        // arrive. Without this, std::async eventfd descriptors
+        // accumulate and eventually exhaust the file descriptor limit.
+        fd_set readfds;
+        FD_ZERO(&readfds);
+        FD_SET(server_fd, &readfds);
 
-        running_connections.push_back(async(launch::async,
-                    &WebRadioInterface::dispatch_client, this, move(client)));
+        struct timeval tv;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
 
+        int sel_ret = select(server_fd + 1, &readfds, nullptr, nullptr, &tv);
+
+        if (sel_ret > 0 && FD_ISSET(server_fd, &readfds)) {
+            auto client = serverSocket.accept();
+            if (client.valid()) {
+                try {
+                    running_connections.push_back(async(launch::async,
+                                &WebRadioInterface::dispatch_client, this, move(client)));
+                }
+                catch (const std::system_error& e) {
+                    cerr << "Thread creation failed: " << e.what()
+                         << " (connection rejected)" << endl;
+                    // Socket 'client' will close via destructor
+                }
+            }
+        }
+
+        // Clean up completed futures — this now runs every second
+        // regardless of whether a new connection arrived
         deque<future<bool> > still_running_connections;
         for (auto& fut : running_connections) {
             if (fut.valid()) {
                 switch (fut.wait_for(chrono::milliseconds(1))) {
                     case future_status::deferred:
+                        // Force deferred futures to execute so they
+                        // don't sit in the queue forever consuming
+                        // resources
+                        fut.wait();
+                        [[fallthrough]];
                     case future_status::timeout:
                         still_running_connections.push_back(move(fut));
                         break;


### PR DESCRIPTION
## Summary

Fixes three related bugs that caused welle-cli to crash after days of operation due to resource exhaustion.

## Bugs Fixed

### 1. CLOSE_WAIT socket leak
`ProgrammeSender::wait_for_termination()` only slept on a condition variable — it never checked whether the TCP socket was alive. Over days, dead sockets accumulated in CLOSE_WAIT until the FD limit was exhausted.

**Fix:** TCP keepalive (`SO_KEEPALIVE`, `TCP_KEEPIDLE=60s`, `TCP_KEEPINTVL=10s`, `TCP_KEEPCNT=3`) on accepted sockets + drain `recv()` on every wait loop iteration to detect peer FIN.

### 2. eventfd leak from std::async
`serve()` used a blocking `accept()` call — stale `std::async` futures were only cleaned up when a new connection arrived. Each async future allocates an internal eventfd that leaked until consumed.

**Fix:** `select()` with 1-second timeout before `accept()`, so cleanup runs every second regardless of new connections.

### 3. MSG_PEEK false negative
`recv(MSG_PEEK | MSG_DONTWAIT)` returned leftover data length instead of 0 even after FIN was received, preventing peer disconnect detection. 614 threads + 611 FDs accumulated over 4 days.

**Fix:** drain-buffer approach — `recv()` into a discard buffer instead of `MSG_PEEK`. Stale data is consumed, and when the buffer is finally empty, `recv()` returns 0 → clean shutdown.

### 4. SIGABRT from uncaught std::system_error
`std::async(launch::async)` throws `std::system_error` ("Resource temporarily unavailable") when the cgroup pids limit is hit. This was not caught, calling `std::terminate()` → SIGABRT crash.

**Fix:** wrap `std::async` in try-catch. Also increased systemd `TasksMax` from default (~759) to 2048.

## Files Changed

| File | Change |
|------|--------|
| `src/various/Socket.h` | + `native_handle()` for select() |
| `src/various/Socket.cpp` | + `#include <netinet/tcp.h>`, keepalive in accept() |
| `src/welle-cli/webprogrammehandler.h` | removed `const` from `wait_for_termination()` |
| `src/welle-cli/webprogrammehandler.cpp` | drain recv() instead of MSG_PEEK, removed const |
| `src/welle-cli/webradiointerface.cpp` | `select()` timeout, deferred handling, try-catch |

5 files changed, 79 insertions(+), 6 deletions(-)

## Testing

Running 24/7 on a Raspberry Pi with two ffmpeg clients reconnecting hourly. Previous crashes occurred within 1-4 days. Current uptime: stable.

## Notes

- The `#include <netinet/tcp.h>` was needed because modern glibc no longer transitively includes it via `<netinet/in.h>`.
- An `#include <sys/select.h>` was added for `select()`/`fd_set`.
- `TasksMax=2048` is set in the systemd unit to prevent SIGABRT from thread creation failures.
    