### PR TITLE
Fixed the RTL-SDR hang by changing the stop/start sequencing in  src/…

### DIFF
--- a/src/input/rtl_sdr.cpp
+++ b/src/input/rtl_sdr.cpp
@@ -162,9 +162,29 @@ bool CRTL_SDR::restart(void)
 
     rtlsdr_set_center_freq(device, frequency + frequencyOffset);
     rtlsdrRunning = true;
+    {
+        std::lock_guard<std::mutex> lock(rtlsdrStartMutex);
+        rtlsdrAsyncStarted = false;
+    }
 
     rtlsdrThread = std::thread(&CRTL_SDR::rtlsdr_read_async_wrapper, this);
     agcThread = std::thread(&CRTL_SDR::agc_timer_thread, this);
+
+    {
+        std::unique_lock<std::mutex> lock(rtlsdrStartMutex);
+        if (!rtlsdrStartCv.wait_for(lock, std::chrono::seconds(1), [this] { return rtlsdrAsyncStarted; })) {
+            std::clog << "RTL_SDR: " << "Async reader did not start in time" << std::endl;
+            rtlsdrRunning = false;
+            rtlsdr_cancel_async(device);
+            if (rtlsdrThread.joinable()) {
+                rtlsdrThread.join();
+            }
+            if (agcThread.joinable()) {
+                agcThread.join();
+            }
+            return false;
+        }
+    }
 
     return true;
 }
@@ -181,13 +201,14 @@ void CRTL_SDR::stop(void)
 
     rtlsdrRunning = false;
 
-    if (agcThread.joinable()) {
-        agcThread.join();
-    }
-
     rtlsdr_cancel_async(device);
+
     if (rtlsdrThread.joinable()) {
         rtlsdrThread.join();
+    }
+
+    if (agcThread.joinable()) {
+        agcThread.join();
     }
 }
 
@@ -202,6 +223,8 @@ float CRTL_SDR::setGain(int gain_index)
         std::clog << "RTL_SDR: " << "Unknown gain count" << gain_index << std::endl;
         return 0;
     }
+
+    std::lock_guard<std::mutex> lock(deviceMutex);
 
     currentGainIndex = gain_index;
     currentGain = gains[gain_index];
@@ -275,9 +298,12 @@ void CRTL_SDR::agc_timer_thread(void)
     while (rtlsdrRunning && not rtlsdrUnplugged) {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
+        const uint8_t currentMinAmplitude = minAmplitude.load(std::memory_order_relaxed);
+        const uint8_t currentMaxAmplitude = maxAmplitude.load(std::memory_order_relaxed);
+
         if (isAGC) {
             // Check for overloading
-            if (minAmplitude == 0 || maxAmplitude == 255) {
+            if (currentMinAmplitude == 0 || currentMaxAmplitude == 255) {
                 // We have to decrease the gain
                 if (currentGainIndex > 0) {
                     setGain(currentGainIndex - 1);
@@ -291,8 +317,8 @@ void CRTL_SDR::agc_timer_thread(void)
                     float DeltaGain = ((float) NewGain / 10) - ((float) currentGain / 10);
                     float LinGain = pow(10, DeltaGain / 20);
 
-                    int NewMaxValue = (float) maxAmplitude * LinGain;
-                    int NewMinValue = (float) minAmplitude / LinGain;
+                    int NewMaxValue = (float) currentMaxAmplitude * LinGain;
+                    int NewMinValue = (float) currentMinAmplitude / LinGain;
 
                     // We have to increase the gain
                     if(NewMinValue >= 0 && NewMaxValue <= 255) {
@@ -376,15 +402,15 @@ void CRTL_SDR::rtlsdr_read_callback(uint8_t* buf, uint32_t len, void* ctx)
         rtlsdr->putIntoRecordBuffer(*buf, len);
 
         // Check if device is overloaded
-        rtlsdr->minAmplitude = 255;
-        rtlsdr->maxAmplitude = 0;
+        rtlsdr->minAmplitude.store(255, std::memory_order_relaxed);
+        rtlsdr->maxAmplitude.store(0, std::memory_order_relaxed);
 
         for (uint32_t i=0;i<len;i++) {
-            if (rtlsdr->minAmplitude > buf[i])
-                rtlsdr->minAmplitude = buf[i];
+            if (rtlsdr->minAmplitude.load(std::memory_order_relaxed) > buf[i])
+                rtlsdr->minAmplitude.store(buf[i], std::memory_order_relaxed);
 
-            if (rtlsdr->maxAmplitude < buf[i])
-                rtlsdr->maxAmplitude = buf[i];
+            if (rtlsdr->maxAmplitude.load(std::memory_order_relaxed) < buf[i])
+                rtlsdr->maxAmplitude.store(buf[i], std::memory_order_relaxed);
         }
     }
     else {
@@ -395,6 +421,11 @@ void CRTL_SDR::rtlsdr_read_callback(uint8_t* buf, uint32_t len, void* ctx)
 void CRTL_SDR::rtlsdr_read_async_wrapper()
 {
     std::clog << "RTL_SDR: " << "Start rtlsdr_read_async_wrapper() thread" << std::endl;
+    {
+        std::lock_guard<std::mutex> lock(rtlsdrStartMutex);
+        rtlsdrAsyncStarted = true;
+    }
+    rtlsdrStartCv.notify_all();
     rtlsdr_read_async(device,
                       (rtlsdr_read_async_cb_t)&CRTL_SDR::rtlsdr_read_callback,
                       (void*)this, 0, READLEN_DEFAULT);

--- a/src/input/rtl_sdr.h
+++ b/src/input/rtl_sdr.h
@@ -37,6 +37,8 @@
 #include <thread>
 #include <string>
 #include <atomic>
+#include <mutex>
+#include <condition_variable>
 #include <rtl-sdr.h>
 
 #include "virtual_input.h"
@@ -86,11 +88,15 @@ private:
     void rtlsdr_read_async_wrapper(void);
     std::atomic<bool> rtlsdrRunning = ATOMIC_VAR_INIT(false);
     std::atomic<bool> rtlsdrUnplugged = ATOMIC_VAR_INIT(false);
+    std::mutex rtlsdrStartMutex;
+    std::condition_variable rtlsdrStartCv;
+    bool rtlsdrAsyncStarted = false;
 
     std::vector<int> gains;
     int currentGainIndex = 0;
-    uint8_t minAmplitude = 255;
-    uint8_t maxAmplitude = 0;
+    std::atomic<uint8_t> minAmplitude {255};
+    std::atomic<uint8_t> maxAmplitude {0};
+    std::mutex deviceMutex;
 
     void agc_timer_thread(void);
 


### PR DESCRIPTION
Fixed the RTL-SDR hang by changing the stop/start sequencing in  src/input/rtl_sdr.cpp :

-  stop()  now cancels async capture before joining the reader/AGC threads.
-  restart()  waits for the async reader thread to actually start before returning, so teardown can’t race startup.
- Added a small synchronization handshake between the main thread and the RTL async thread.

----

#### What does this PR do and why is it necessary?
`welle-io` GUI hangs under FC44 very frequently. GUI becomes unresponsive.

#### How was it tested? How can it be tested by the reviewer?
Start welle-io and try playback

```
2026-07-23T11:45:22.117 Info: Using Qt multimedia with FFmpeg version 8.1.2 GPL version 3 or later
2026-07-23T11:45:22.654 Info: InputFactory:Input device:auto
2026-07-23T11:45:22.655 Info: RTL_SDR: Open rtl-sdr
2026-07-23T11:45:22.676 Info: RTL_SDR: Found 1 devices. Uses the first working one
Found Rafael Micro R820T tuner
2026-07-23T11:45:23.079 Info: RTL_SDR:  Opening rtl-sdr device0
[R82XX] PLL not locked!
2026-07-23T11:45:23.152 Warning: spaVisitChoice: parse error "Object: size 144, type Spa:Pod:Object:Param:Format (262147), id Spa:Enum:ParamId:EnumFormat (3)" "  Prop: key Spa:Pod:Object:Param:Format:mediaType (1), flags 00000000" "    Id 1        (Spa:Enum:MediaType:audio)" "  Prop: key Spa:Pod:Object:Param:Format:mediaSubtype (2), flags 00000000" "    Id 3        (Spa:Enum:MediaSubtype:iec958)" "  Prop: key Spa:Pod:Object:Param:Format:Audio:iec958Codec (65542), flags 00000000" "    Choice: type Spa:Enum:Choice:Enum, flags 00000000 24 4" "      Id 1        (Spa:Enum:AudioIEC958Codec:PCM)" "      Id 1        (Spa:Enum:AudioIEC958Codec:PCM)" "  Prop: key Spa:Pod:Object:Param:Format:Audio:rate (65539), flags 00000000" "    Choice: type Spa:Enum:Choice:Range, flags 00000000 28 4" "      Int 48000" "      Int 32000" "      Int 192000"
2026-07-23T11:45:23.192 Info: RTL_SDR:  Supported gain values29
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 49.6
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 48
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 44.5
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 43.9
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 43.4
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 42.1
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 40.2
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 38.6
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 37.2
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 36.4
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 33.8
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 32.8
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 29.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 28
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 25.4
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 22.9
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 20.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 19.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 16.6
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 15.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 14.4
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 12.5
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 8.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 7.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 3.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 2.7
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 1.4
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 0.9
2026-07-23T11:45:23.193 Info: RTL_SDR:  gain 0
2026-07-23T11:45:23.228 Info: RTL_SDR: Set bias tee to 0
2026-07-23T11:45:23.228 Info: RTL_SDR: Error: rtlsdr_set_bias_tee() not defined!
2026-07-23T11:45:23.283 Warning: qrc:/QML/components/ViewBaseFrame.qml:57:9: QML MenuItem: Created graphical object was not placed in the graphics scene.
2026-07-23T11:45:25.226 Info: RTL_SDR: Start rtlsdr_read_async_wrapper() thread
```

#### Any background context you want to provide?
The issue used to happened earlier as well, but with FC44 it occurs very often.

#### What are the relevant tickets if any?
Did not found any.

#### Screenshots (if appropriate)
None

#### Further notes
None