### PR TITLE
Android: sign the release APK so it can be installed

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -294,6 +294,56 @@ jobs:
       - name: Display environment variables
         run: env | sort
 
+      # A release APK is not signed by gradle, so androiddeployqt has to sign it
+      # (it is called with --sign through QT_ANDROID_SIGN_APK below). Without
+      # this the build silently produces *-release-unsigned.apk, which Android
+      # refuses to install. See issue #814.
+      # If the repository provides a release keystore through its secrets it is
+      # used, otherwise a throw-away key is generated so that nightly builds and
+      # builds from forks stay installable.
+      - name: Prepare signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_ALIAS: ${{ secrets.ANDROID_KEYSTORE_ALIAS }}
+          ANDROID_KEYSTORE_STORE_PASS: ${{ secrets.ANDROID_KEYSTORE_STORE_PASS }}
+          ANDROID_KEYSTORE_KEY_PASS: ${{ secrets.ANDROID_KEYSTORE_KEY_PASS }}
+        run: |
+            # Never use "set -x" here, it would leak the passwords into the log
+            set -eu
+            KEYSTORE_PATH="${HOME}/welle-io-release.keystore"
+
+            if [ -n "${ANDROID_KEYSTORE_BASE64:-}" ]; then
+                echo "Signing with the release keystore from the repository secrets"
+                echo "${ANDROID_KEYSTORE_BASE64}" | base64 -d > "${KEYSTORE_PATH}"
+                KEYSTORE_ALIAS="${ANDROID_KEYSTORE_ALIAS}"
+                KEYSTORE_STORE_PASS="${ANDROID_KEYSTORE_STORE_PASS}"
+                KEYSTORE_KEY_PASS="${ANDROID_KEYSTORE_KEY_PASS:-${ANDROID_KEYSTORE_STORE_PASS}}"
+            else
+                echo "No ANDROID_KEYSTORE_BASE64 secret is set, generating a throw-away key."
+                echo "The APK will be installable, but it cannot be used to upgrade an"
+                echo "installation that was signed with the official welle.io key."
+                KEYSTORE_ALIAS="welle-io"
+                KEYSTORE_STORE_PASS="$(openssl rand -hex 16)"
+                KEYSTORE_KEY_PASS="${KEYSTORE_STORE_PASS}"
+                echo "::add-mask::${KEYSTORE_STORE_PASS}"
+                keytool -genkeypair \
+                  -keystore "${KEYSTORE_PATH}" \
+                  -alias "${KEYSTORE_ALIAS}" \
+                  -keyalg RSA -keysize 2048 -validity 10000 \
+                  -storepass "${KEYSTORE_STORE_PASS}" \
+                  -keypass "${KEYSTORE_KEY_PASS}" \
+                  -dname "CN=welle.io, O=welle.io, C=DE"
+            fi
+
+            echo "::add-mask::${KEYSTORE_STORE_PASS}"
+            echo "::add-mask::${KEYSTORE_KEY_PASS}"
+
+            # Read by androiddeployqt when it is invoked with --sign
+            echo "QT_ANDROID_KEYSTORE_PATH=${KEYSTORE_PATH}" >> $GITHUB_ENV
+            echo "QT_ANDROID_KEYSTORE_ALIAS=${KEYSTORE_ALIAS}" >> $GITHUB_ENV
+            echo "QT_ANDROID_KEYSTORE_STORE_PASS=${KEYSTORE_STORE_PASS}" >> $GITHUB_ENV
+            echo "QT_ANDROID_KEYSTORE_KEY_PASS=${KEYSTORE_KEY_PASS}" >> $GITHUB_ENV
+
       - name: Configure welle.io project
         run: |
             set -x
@@ -309,6 +359,7 @@ jobs:
             ${QT_INSTALL_BINDIR}/qt-cmake \
               -DQT_ANDROID_BUILD_ALL_ABIS=TRUE \
               -DQT_ANDROID_DEPLOY_RELEASE=TRUE \
+              -DQT_ANDROID_SIGN_APK=ON \
               -DQT_PATH_ANDROID_ABI_armeabi-v7a="${{ env.QT_PATH_ANDROID_ABI_armeabi-v7a }}" \
               -DQT_PATH_ANDROID_ABI_arm64-v8a="${{ env.QT_PATH_ANDROID_ABI_arm64-v8a }}" \
               -DQT_PATH_ANDROID_ABI_x86="${{ env.QT_PATH_ANDROID_ABI_x86 }}" \
@@ -331,9 +382,24 @@ jobs:
             cmake --build "build" --parallel
             ls -al build/android-build/build/outputs/apk/*/*.apk
 
+            # An unsigned APK cannot be installed on Android and that stayed
+            # unnoticed for a long time (issue #814), so refuse to publish one.
+            APKSIGNER="${MY_ANDROID_SDK_ROOT}/build-tools/${ANDROID_BUILD_TOOLS_VER}/apksigner"
+            SIGNED_APK=""
+            for apk in build/android-build/build/outputs/apk/*/*.apk; do
+                if "${APKSIGNER}" verify --verbose "${apk}"; then
+                    SIGNED_APK="${apk}"
+                    break
+                fi
+            done
+            if [ -z "${SIGNED_APK}" ]; then
+                echo "::error::No signed APK was produced, the package would not be installable."
+                exit 1
+            fi
+
             # prepare the publish
             mkdir publish
-            cp build/android-build/build/outputs/apk/*/*.apk publish/${DATE}_${LAST_COMMIT_HASH}_Android_welle-io.apk
+            cp "${SIGNED_APK}" publish/${DATE}_${LAST_COMMIT_HASH}_Android_welle-io.apk
             find publish/
 
       - name: Upload to nightly server


### PR DESCRIPTION
Fixes #814

## The problem

The workflow configures the project with `QT_ANDROID_DEPLOY_RELEASE=TRUE`, which makes Qt pass `--release` to `androiddeployqt` ([`Qt6AndroidMacros.cmake#L467`](https://github.com/qt/qtbase/blob/6.5/src/corelib/Qt6AndroidMacros.cmake#L467)).

Signing was never enabled though. `QT_ANDROID_SIGN_APK`, which is what makes Qt add `--sign` ([same file, L452](https://github.com/qt/qtbase/blob/6.5/src/corelib/Qt6AndroidMacros.cmake#L452)), was not set, so `androiddeployqt` took its `UnsignedAPK` code path and the job produced `android-build-release-unsigned.apk`.

Android refuses to install a package without a signature, which is why the nightly builds and the action artifacts could not be installed on any device. The Qt sources even spell it out in a nearby comment: *"Release package need to be signed."*

The publish step then did `cp build/android-build/build/outputs/apk/*/*.apk`, so the unsigned APK was copied to the nightly server without anything noticing.

I reproduced it outside of CI with `androiddeployqt --release` and no `--sign`:

```
$ apksigner verify --verbose android-build-release-unsigned.apk
DOES NOT VERIFY
ERROR: No JAR signatures
```

The resulting APK has no `.SF`/`.RSA` entry in `META-INF`. Adding the signing step gives `Verifies / v1 scheme: true / v2 scheme: true`.

## The fix

* **Enable `QT_ANDROID_SIGN_APK`** so Qt passes `--sign` to `androiddeployqt`.
* **New `Prepare signing keystore` step** providing the keystore that `androiddeployqt` reads from `QT_ANDROID_KEYSTORE_PATH` / `_ALIAS` / `_STORE_PASS` / `_KEY_PASS`.
  * If the repository defines the `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_ALIAS`, `ANDROID_KEYSTORE_STORE_PASS` and `ANDROID_KEYSTORE_KEY_PASS` secrets, the official release key is used.
  * Otherwise a throw-away key is generated, so nightly builds and builds from forks stay installable without any secret being configured. Such a build cannot upgrade an install signed with the official key, and the log says so.
  * The step is placed after `Display environment variables` so the passwords are not printed by its `env | sort`, it never uses `set -x`, and the passwords are registered with `::add-mask::`.
* **Verify before publishing**: the produced APK is checked with `apksigner verify` and the job now fails if no signed package is found, so an uninstallable APK cannot be shipped again silently.

To use the official key, add the four secrets, the keystore being `base64 -w0 my-release.keystore`.

## Testing

* Both branches of the new step were run locally: key generation, and restoring a keystore from a base64 secret (byte-identical to the source, with `KEY_PASS` correctly falling back to `STORE_PASS` when unset).
* The `apksigner` guard was tested against a real unsigned APK (fails the job, as intended) and a real signed one (picked up correctly).
* The workflow file still parses as valid YAML and the step order is unchanged apart from the insertion.

I could not run the full workflow end to end, since it needs the `qt-android-6.5` packages from the third-party apt repository and a GitHub runner. The signing logic itself is verified against the Qt 6.5 sources and by the local tests above, but the first real CI run still deserves a look.

Note that the workflow is currently disabled in the repository settings, so it will have to be re-enabled manually to run.
