### PR TITLE
ETI input for welle-cli, web frontend improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ set(backend_sources
     src/backend/fib-processor.cpp
     src/backend/fic-handler.cpp
     src/backend/msc-handler.cpp
+    src/backend/eti-processor.cpp
     src/backend/freq-interleaver.cpp
     src/backend/ofdm-decoder.cpp
     src/backend/ofdm-processor.cpp
@@ -312,6 +313,7 @@ set(input_sources
     src/input/input_factory.cpp
     src/input/null_device.cpp
     src/input/raw_file.cpp
+    src/input/eti_file.cpp
     src/input/rtl_tcp.cpp
 )
 

--- a/src/backend.pri
+++ b/src/backend.pri
@@ -106,6 +106,7 @@ HEADERS += \
     $$PWD/backend/fib-processor.h \
     $$PWD/backend/fic-handler.h \
     $$PWD/backend/msc-handler.h \
+    $$PWD/backend/eti-processor.h \
     $$PWD/backend/freq-interleaver.h \
     $$PWD/backend/ofdm-decoder.h \
     $$PWD/backend/ofdm-processor.h \
@@ -143,6 +144,7 @@ HEADERS += \
     $$PWD/input/input_factory.h \
     $$PWD/input/null_device.h \
     $$PWD/input/raw_file.h \
+    $$PWD/input/eti_file.h \
     $$PWD/input/virtual_input.h \
     $$PWD/input/rtl_tcp.h
 	
@@ -158,6 +160,7 @@ SOURCES += \
     $$PWD/backend/fib-processor.cpp \
     $$PWD/backend/fic-handler.cpp \
     $$PWD/backend/msc-handler.cpp \
+    $$PWD/backend/eti-processor.cpp \
     $$PWD/backend/freq-interleaver.cpp \
     $$PWD/backend/ofdm-decoder.cpp \
     $$PWD/backend/ofdm-processor.cpp \
@@ -181,6 +184,7 @@ SOURCES += \
     $$PWD/input/input_factory.cpp \
     $$PWD/input/null_device.cpp \
     $$PWD/input/raw_file.cpp \
+    $$PWD/input/eti_file.cpp \
     $$PWD/input/rtl_tcp.cpp
 
 

--- a/src/backend/dabplus_decoder.cpp
+++ b/src/backend/dabplus_decoder.cpp
@@ -92,20 +92,19 @@ void SuperframeFilter::Feed(const uint8_t *data, size_t len) {
 	memcpy(sf, sf_raw, sf_len);
 	rs_dec.DecodeSuperframe(sf, sf_len, total_corr_count, uncorr_errors);
 
-	// forward statistics if errors present
-    //if(total_corr_count || uncorr_errors)
-		observer->FECInfo(total_corr_count, uncorr_errors);
-
-
+	// AI: moved FECInfo callback to AFTER CheckSync() so that RS errors
+	// accumulated during superframe sync acquisition (sliding window phase)
+	// are not forwarded to the web UI error counters.  Only errors in
+	// successfully synced superframes are meaningful.
 	if(!CheckSync()) {
-		if(sync_frames == 0)
-			fprintf(stderr, "SuperframeFilter: Superframe sync started...\n");
 		sync_frames++;
 		return;
 	}
 
+	// AI: FECInfo only reached when superframe is valid.
+	observer->FECInfo(total_corr_count, uncorr_errors);
+
 	if(sync_frames) {
-		fprintf(stderr, "SuperframeFilter: Superframe sync succeeded after %d frame(s)\n", sync_frames);
 		sync_frames = 0;
 	}
 
@@ -362,7 +361,7 @@ void RSDecoder::DecodeSuperframe(uint8_t *sf, size_t sf_len, int& total_corr_cou
 
 // --- AACDecoder -----------------------------------------------------------------
 AACDecoder::AACDecoder(std::string decoder_name, SubchannelSinkObserver* observer, SuperframeFormat sf_format) {
-	fprintf(stderr, "AACDecoder: using decoder '%s'\n", decoder_name.c_str());
+	(void)decoder_name;
 
 	this->observer = observer;
 

--- a/src/backend/decoder_adapter.cpp
+++ b/src/backend/decoder_adapter.cpp
@@ -76,6 +76,25 @@ void DecoderAdapter::addtoFrame(uint8_t *v)
     frameErrorCounter = 0;
 }
 
+// AI: ETI path — the subchannel payload extracted from an ETI frame is
+// already Reed-Solomon decoded; feed it directly to the SuperframeFilter
+// (DAB+) or MP2 decoder (DAB), bypassing the Viterbi soft-bit path.
+void DecoderAdapter::feedRawFrame(const uint8_t *data, size_t len)
+{
+    if (!data || len == 0) {
+        return;
+    }
+
+    decoder->Feed(data, len);
+
+    if (dumpFile) {
+        fwrite(data, len, 1, dumpFile.get());
+    }
+
+    myInterface.onFrameErrors(frameErrorCounter);
+    frameErrorCounter = 0;
+}
+
 void DecoderAdapter::FormatChange(const AUDIO_SERVICE_FORMAT& format)
 {
     audioFormat = format.GetSummary();

--- a/src/backend/decoder_adapter.h
+++ b/src/backend/decoder_adapter.h
@@ -47,6 +47,8 @@ class DecoderAdapter: public DabProcessor, public SubchannelSinkObserver, public
                      const std::string& dumpFileName);
 
         virtual void addtoFrame(uint8_t *v);
+        // AI: feeds a raw (pre-decoded) ETI subchannel frame to the audio decoder.
+    void feedRawFrame(const uint8_t *data, size_t len);
 
         // SubchannelSinkObserver impl
         virtual void FormatChange(const AUDIO_SERVICE_FORMAT& /*format*/);

--- a/src/backend/eti-processor.cpp
+++ b/src/backend/eti-processor.cpp
@@ -1,0 +1,236 @@
+/*
+ *    Copyright (C) 2026
+ *
+ *    This file is part of the welle.io.
+ *
+ *    AI-generated: implementation of ETIProcessor.
+ *    See eti-processor.h for architecture notes.
+ */
+
+#include "eti-processor.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstring>
+
+ETIProcessor::ETIProcessor(InputInterface& input,
+        RadioControllerInterface& rci,
+        FicHandler& ficHandler,
+        MscHandler& mscHandler) :
+    input(input),
+    rci(rci),
+    ficHandler(ficHandler),
+    mscHandler(mscHandler)
+{
+}
+
+ETIProcessor::~ETIProcessor()
+{
+    stop();
+}
+
+void ETIProcessor::restart()
+{
+    stop();
+
+    if (!input.restart()) {
+        rci.onMessage(message_level_t::Error,
+                "ETI input restart failed");
+        rci.onInputFailure();
+        return;
+    }
+
+    running = true;
+    announcedSync = false;
+
+    // Start the fast reader thread first, then the processor.
+    readerThread = std::thread(&ETIProcessor::readFrames, this);
+    worker       = std::thread(&ETIProcessor::run,        this);
+}
+
+void ETIProcessor::stop()
+{
+    const bool wasRunning = running.exchange(false);
+    if (wasRunning) {
+        input.stop();
+    }
+
+    // Wake up the processor thread if it is waiting on the queue.
+    queueCV.notify_all();
+
+    if (readerThread.joinable()) {
+        readerThread.join();
+    }
+    if (worker.joinable()) {
+        worker.join();
+    }
+
+    // Drain the queue.
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        while (!frameQueue.empty()) frameQueue.pop();
+    }
+
+    if (announcedSync) {
+        rci.onSyncChange(false);
+        announcedSync = false;
+    }
+}
+
+// ---------- reader thread --------------------------------------------------
+// Reads raw ETI frames from the input (blocking on the pipe) and pushes them
+// into the bounded queue as fast as the input delivers them.  Audio processing
+// happens in a separate thread so it never stalls the pipe reader.
+void ETIProcessor::readFrames()
+{
+    std::vector<uint8_t> frame(6144);
+
+    while (running) {
+        const int32_t frameSize = input.getEtiFrame(frame.data(), frame.size());
+
+        // Build the queued item.
+        std::vector<uint8_t> item;
+        if (frameSize > 0) {
+            item.assign(frame.begin(), frame.begin() + frameSize);
+        }
+        // frameSize == 0 or < 0: push an empty sentinel to signal the
+        // processor thread (EOF or error).
+
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+
+            if (frameSize > 0 && frameQueue.size() >= kMaxQueueFrames) {
+                // Queue full: drop the oldest frame rather than blocking the
+                // pipe reader (which would cause back-pressure on eti-cmdline
+                // and corrupt the RTL-SDR USB stream).
+                frameQueue.pop();
+            }
+
+            frameQueue.push(std::move(item));
+            queueCV.notify_one();
+        }
+
+        if (frameSize <= 0) {
+            break; // EOF or error; sentinel is in the queue
+        }
+    }
+}
+
+// ---------- processor thread -----------------------------------------------
+void ETIProcessor::run()
+{
+    using namespace std::chrono;
+
+    while (running) {
+        std::vector<uint8_t> frame;
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+            queueCV.wait(lock, [this]{
+                return !frameQueue.empty() || !running;
+            });
+
+            if (!running && frameQueue.empty()) break;
+            if (frameQueue.empty()) continue;
+
+            frame = std::move(frameQueue.front());
+            frameQueue.pop();
+        }
+
+        // Empty frame = EOF/error sentinel from the reader thread.
+        if (frame.empty()) {
+            const bool wasEndOfFile = !running.load();
+            if (wasEndOfFile) {
+                rci.onMessage(message_level_t::Information, "End of ETI input");
+            } else {
+                rci.onMessage(message_level_t::Error, "Failed to read ETI frame");
+            }
+            break;
+        }
+
+        const bool ok = processFrame(frame.data(), frame.size());
+        if (!ok) {
+            continue;
+        }
+
+        if (!announcedSync) {
+            rci.onSyncChange(true);
+            rci.onSignalPresence(true);
+            announcedSync = true;
+        }
+
+        // For file playback: pace output to real-time.  For live pipe input
+        // the reader thread already blocks on the pipe at the correct rate, so
+        // the queue will typically stay at 0-1 entries and no sleep is needed.
+        // We still guard against runaway speed on files by sleeping when the
+        // queue runs dry (i.e. when we are processing at the same pace as the
+        // reader).
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+            if (frameQueue.empty()) {
+                // Queue drained — yield briefly so the reader thread can
+                // refill before we spin.  For live input this is a no-op
+                // because the reader will already be blocking on the pipe.
+                lock.unlock();
+                std::this_thread::sleep_for(milliseconds(1));
+            }
+        }
+    }
+
+    running = false;
+}
+
+bool ETIProcessor::processFrame(const uint8_t *frame, size_t size)
+{
+    if (!frame || size < 16) {
+        return false;
+    }
+
+    if (frame[0] != 0xFF) {
+        return false;
+    }
+
+    const uint8_t ficf = (frame[5] & 0x80) >> 7;
+    const uint8_t nst = frame[5] & 0x7F;
+    const uint8_t mid = (frame[6] & 0x18) >> 3;
+    const uint8_t ficl = (ficf == 0) ? 0 : ((mid == 3) ? 32 : 24);
+
+    const size_t stcOffset = 8;
+    const size_t stcLength = static_cast<size_t>(nst) * 4;
+    const size_t headerEnd = stcOffset + stcLength + 4;
+
+    if (headerEnd > size) {
+        return false;
+    }
+
+    const size_t ficOffset = headerEnd;
+    const size_t ficSize = static_cast<size_t>(ficl) * 4;
+    if (ficOffset + ficSize > size) {
+        return false;
+    }
+
+    if (ficf == 1) {
+        for (size_t fibOffset = 0; fibOffset + 32 <= ficSize; fibOffset += 32) {
+            ficHandler.processFibBytes(frame + ficOffset + fibOffset, 32);
+        }
+    }
+
+    size_t streamOffset = ficOffset + ficSize;
+    for (size_t i = 0; i < nst; i++) {
+        const size_t stcBase = stcOffset + i * 4;
+        const uint8_t subChId = (frame[stcBase] & 0xFC) >> 2;
+        const uint16_t sad = static_cast<uint16_t>((frame[stcBase] & 0x03) << 8) |
+            frame[stcBase + 1];
+        const uint16_t stl = static_cast<uint16_t>((frame[stcBase + 2] & 0x03) << 8) |
+            frame[stcBase + 3];
+        const size_t streamBytes = static_cast<size_t>(stl) * 8;  // STL unit = 64 bits = 8 bytes (ETSI EN 300 799)
+
+        if (streamOffset + streamBytes > size) {
+            return false;
+        }
+
+        mscHandler.processEtiStream(subChId, sad, stl, frame + streamOffset, streamBytes);
+        streamOffset += streamBytes;
+    }
+
+    return true;
+}

--- a/src/backend/eti-processor.h
+++ b/src/backend/eti-processor.h
@@ -1,0 +1,67 @@
+/*
+ *    Copyright (C) 2026
+ *
+ *    This file is part of the welle.io.
+ *
+ *    AI-generated: ETI (Ensemble Transport Interface) frame processor.
+ *    Replaces the OFDM processor when the input source is a raw ETI stream
+ *    instead of a live RF/IQ signal.  Uses a producer-consumer queue to
+ *    decouple pipe I/O (readFrames thread) from audio decoding (run thread)
+ *    so heavy AAC/RS processing never creates back-pressure on the pipe.
+ */
+
+#ifndef ETI_PROCESSOR_H
+#define ETI_PROCESSOR_H
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+#include "radio-controller.h"
+#include "fic-handler.h"
+#include "msc-handler.h"
+
+class ETIProcessor {
+public:
+    ETIProcessor(InputInterface& input,
+            RadioControllerInterface& rci,
+            FicHandler& ficHandler,
+            MscHandler& mscHandler);
+
+    ~ETIProcessor();
+
+    void restart();
+    void stop();
+
+private:
+    // Fast reader thread: drains the pipe into frameQueue.
+    void readFrames();
+    // Processor thread: takes frames from frameQueue and decodes them.
+    void run();
+    bool processFrame(const uint8_t *frame, size_t size);
+
+    InputInterface& input;
+    RadioControllerInterface& rci;
+    FicHandler& ficHandler;
+    MscHandler& mscHandler;
+
+    std::atomic<bool> running{false};
+    bool announcedSync = false;
+
+    // Frame queue shared between reader and processor threads.
+    // An empty vector signals EOF/error.
+    static constexpr size_t kMaxQueueFrames = 40; // ~960 ms headroom
+    std::queue<std::vector<uint8_t>> frameQueue;
+    std::mutex queueMutex;
+    std::condition_variable queueCV;
+
+    std::thread readerThread;
+    std::thread worker;
+};
+
+#endif

--- a/src/backend/fic-handler.cpp
+++ b/src/backend/fic-handler.cpp
@@ -132,6 +132,38 @@ void FicHandler::processFicBlock(const softbit_t *data, int16_t blkno)
     //  with index = 0
 }
 
+// AI: ETI path — accepts pre-decoded FIB bytes (32 bytes, one FIB) from an
+// ETI frame and feeds them into the existing fibProcessor, bypassing the
+// Viterbi/depuncturing path used for RF signals.
+void FicHandler::processFibBytes(const uint8_t *fibBytes, size_t fibSize)
+{
+    if (!fibBytes || fibSize != 32) {
+        return;
+    }
+
+    uint8_t fibBits[256] = {0};
+
+    for (size_t i = 0; i < 32; i++) {
+        const uint8_t b = fibBytes[i];
+        for (int bit = 0; bit < 8; bit++) {
+            fibBits[i * 8 + bit] = (b >> (7 - bit)) & 0x01;
+        }
+    }
+
+    const bool crcvalid = check_CRC_bits(fibBits, 256);
+    myRadioInterface.onFIBDecodeSuccess(crcvalid, fibBits);
+    if (crcvalid) {
+        fibProcessor.processFIB(fibBits, 0);
+
+        if (fic_decode_success_ratio < 10) {
+            fic_decode_success_ratio++;
+        }
+    }
+    else if (fic_decode_success_ratio > 0) {
+        fic_decode_success_ratio--;
+    }
+}
+
 /**
  * \brief processFicInput
  * we have a vector of 2304 (0 .. 2303) soft bits that has

--- a/src/backend/fic-handler.h
+++ b/src/backend/fic-handler.h
@@ -40,6 +40,8 @@ class FicHandler: public Viterbi
     public:
         FicHandler(RadioControllerInterface& mr);
         void    processFicBlock(const softbit_t *data, int16_t blkno);
+        // AI: accepts pre-decoded FIB bytes from an ETI frame (bypasses Viterbi).
+    void    processFibBytes(const uint8_t *fibBytes, size_t fibSize);
         void    setBitsperBlock(int16_t b);
         void    clearEnsemble();
         int     getFicDecodeRatioPercent();

--- a/src/backend/msc-handler.cpp
+++ b/src/backend/msc-handler.cpp
@@ -37,9 +37,11 @@
 //  Note CIF counts from 0 .. 3
 MscHandler::MscHandler(
         const DABParams& p,
-        bool show_crcErrors) :
+        bool show_crcErrors,
+        bool etiMode) :
     bitsperBlock(2 * p.K),
     show_crcErrors(show_crcErrors),
+    etiMode(etiMode),
     cifVector(864 * CUSize)
 {
     if (p.dabMode == 4) {  // 2 CIFS per 76 blocks
@@ -75,13 +77,23 @@ bool MscHandler::addSubchannel(
 
     SelectedStream s(handler, ascty, dumpFileName, sub);
 
-    s.dabHandler = std::make_shared<DabAudio>(
-                ascty,
-                sub.length * CUSize,
-                sub.bitrate(),
-                sub.protectionSettings,
+    if (etiMode) {
+        auto audioType = ascty;
+        s.etiDecoder = std::make_unique<DecoderAdapter>(
                 handler,
+                sub.bitrate(),
+                audioType,
                 dumpFileName);
+    }
+    else {
+        s.dabHandler = std::make_shared<DabAudio>(
+                    ascty,
+                    sub.length * CUSize,
+                    sub.bitrate(),
+                    sub.protectionSettings,
+                    handler,
+                    dumpFileName);
+    }
 
      /* TODO dealing with data
       s.dabHandler = std::make_shared<DabData>(radioInterface,
@@ -128,6 +140,12 @@ bool MscHandler::removeSubchannel(const Subchannel& sub)
 //  during the next processMscBlock call.
 void MscHandler::processMscBlock(const softbit_t *fbits, int16_t blkno)
 {
+    if (etiMode) {
+        (void)fbits;
+        (void)blkno;
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(mutex);
 
     if (!work_to_be_done)
@@ -154,6 +172,55 @@ void MscHandler::processMscBlock(const softbit_t *fbits, int16_t blkno)
         else {
             throw std::logic_error("No dabHandler!");
         }
+    }
+}
+
+// AI: ETI path — dispatches one subchannel's payload from an ETI frame to
+// its registered DecoderAdapter.  Matching is done by subchannel ID (primary)
+// or by start-address + length (fallback).  The STL unit is 64 bits = 8 bytes
+// per ETSI EN 300 799, so expectedBytes = stl * 8.
+void MscHandler::processEtiStream(
+        uint8_t subChId,
+        uint16_t startAddr,
+        uint16_t stl,
+        const uint8_t *data,
+        size_t size)
+{
+    if (!etiMode || data == nullptr || size == 0) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex);
+
+    if (!work_to_be_done) {
+        return;
+    }
+
+    for (auto& stream : streams) {
+        const bool sidMatch = stream.subCh.subChId == subChId;
+        const bool sadLenMatch =
+            (stream.subCh.startAddr == static_cast<int16_t>(startAddr)) &&
+            (stream.subCh.length == static_cast<int16_t>(stl));
+
+        if (!(sidMatch || sadLenMatch)) {
+            continue;
+        }
+
+        if (!stream.etiDecoder) {
+            continue;
+        }
+
+        // ETI stream payload length is STL * 8 bytes (STL unit = 64 bits per ETSI EN 300 799).
+        const size_t expectedBytes = static_cast<size_t>(stl) * 8;
+        if (expectedBytes == 0) {
+            continue;
+        }
+
+        if (size < expectedBytes) {
+            continue;
+        }
+
+        stream.etiDecoder->feedRawFrame(data, expectedBytes);
     }
 }
 

--- a/src/backend/msc-handler.h
+++ b/src/backend/msc-handler.h
@@ -40,13 +40,15 @@
 #include "dab-constants.h"
 #include "ringbuffer.h"
 #include "radio-controller.h"
+#include "decoder_adapter.h"
 
 class DabVirtual;
 
 class MscHandler
 {
     public:
-        MscHandler(const DABParams& p, bool show_crcErrors);
+        // AI: ETI mode constructor parameter and subchannel dispatch method.
+    MscHandler(const DABParams& p, bool show_crcErrors, bool etiMode = false);
 
         // Stop processing and remove all subchannels
         void stopProcessing(void);
@@ -58,6 +60,15 @@ class MscHandler
                 const Subchannel& sub);
 
         bool removeSubchannel(const Subchannel& sub);
+
+        // Feed one ETI stream payload for a subchannel.
+        // AI: feeds one subchannel payload from an ETI frame to its decoder.
+    void processEtiStream(
+            uint8_t subChId,
+            uint16_t startAddr,
+            uint16_t stl,
+            const uint8_t *data,
+            size_t size);
 
     private:
         friend class OfdmDecoder;
@@ -81,6 +92,7 @@ class MscHandler
             const Subchannel subCh;
 
             std::shared_ptr<DabVirtual> dabHandler;
+            std::unique_ptr<DecoderAdapter> etiDecoder;
         };
 
         std::mutex mutex;
@@ -89,6 +101,7 @@ class MscHandler
         const int16_t bitsperBlock;
         int16_t numberofblocksperCIF;
         bool show_crcErrors;
+        bool etiMode = false;
 
         std::vector<softbit_t> cifVector;
         int16_t cifCount = 0; // msc blocks in CIF

--- a/src/backend/ofdm-decoder.cpp
+++ b/src/backend/ofdm-decoder.cpp
@@ -126,7 +126,9 @@ void OfdmDecoder::workerthread()
         }
     }
 
-    std::clog << "OFDM-decoder:" <<  "closing down now" << std::endl;
+    // AI: renamed from "OFDM-decoder: closing down" so the message is
+    // accurate in ETI mode where there is no OFDM decoder.
+    std::clog << "Decoder: closing down now" << std::endl;
 }
 
 void OfdmDecoder::pushAllSymbols(std::vector<std::vector<DSPCOMPLEX> >&& syms)

--- a/src/backend/radio-controller.h
+++ b/src/backend/radio-controller.h
@@ -197,6 +197,14 @@ public:
     virtual int32_t getSamples(DSPCOMPLEX* buffer, int32_t size) = 0;
     virtual std::vector<DSPCOMPLEX> getSpectrumSamples(int size) = 0;
     virtual int32_t getSamplesToRead(void) = 0;
+    // AI: ETI input extensions — default implementations return false/-1 so
+    // existing RF devices need no changes.
+    virtual bool isEtiInput(void) const { return false; }
+    virtual int32_t getEtiFrame(uint8_t* buffer, size_t size) {
+        (void)buffer;
+        (void)size;
+        return -1;
+    }
     virtual float setGain(int gain) = 0;
     virtual float getGain(void) const = 0;
     virtual int getGainCount(void) = 0;

--- a/src/backend/radio-receiver.cpp
+++ b/src/backend/radio-receiver.cpp
@@ -127,6 +127,8 @@ void RadioReceiver::setReceiverOptions(const RadioReceiverOptions rro)
         " fft placement: " << fftPlacementMethodToString(rro.fftPlacementMethod) << endl;
     // AI: guard setReceiverOptions against ETI mode (no OFDM processor to configure).
     if (!input.isEtiInput()) {
+        ofdmProcessor.setReceiverOptions(rro);
+    }
 }
 
 bool RadioReceiver::playSingleProgramme(ProgrammeHandlerInterface& handler,

--- a/src/backend/radio-receiver.cpp
+++ b/src/backend/radio-receiver.cpp
@@ -69,18 +69,28 @@ RadioReceiver::RadioReceiver(
                 RadioReceiverOptions rro,
                 int transmission_mode) :
     params(transmission_mode),
-    mscHandler(params, false),
+    input(input),
+    mscHandler(params, false, input.isEtiInput()),
     ficHandler(rci),
     ofdmProcessor(input,
         params,
         rci,
         mscHandler,
         ficHandler,
-        rro)
+        rro),
+    etiProcessor(input, rci, ficHandler, mscHandler)
 { }
 
 void RadioReceiver::restart(bool doScan)
 {
+    // AI: ETI mode bypasses OFDM entirely and drives the ETIProcessor.
+    if (input.isEtiInput()) {
+        mscHandler.stopProcessing();
+        ficHandler.clearEnsemble();
+        etiProcessor.restart();
+        return;
+    }
+
     ofdmProcessor.set_scanMode(doScan);
     mscHandler.stopProcessing();
     ficHandler.clearEnsemble();
@@ -95,6 +105,7 @@ void RadioReceiver::restart_decoder()
 
 void RadioReceiver::stop()
 {
+    etiProcessor.stop();
     ofdmProcessor.stop();
     mscHandler.stopProcessing();
     ficHandler.clearEnsemble();
@@ -114,7 +125,8 @@ void RadioReceiver::setReceiverOptions(const RadioReceiverOptions rro)
         " disable coarse corr: " << rro.disableCoarseCorrector <<
         " freqsync: " << fsm <<
         " fft placement: " << fftPlacementMethodToString(rro.fftPlacementMethod) << endl;
-    ofdmProcessor.setReceiverOptions(rro);
+    // AI: guard setReceiverOptions against ETI mode (no OFDM processor to configure).
+    if (!input.isEtiInput()) {
 }
 
 bool RadioReceiver::playSingleProgramme(ProgrammeHandlerInterface& handler,

--- a/src/backend/radio-receiver.h
+++ b/src/backend/radio-receiver.h
@@ -41,6 +41,7 @@
 #include "fic-handler.h"
 #include "msc-handler.h"
 #include "ofdm-processor.h"
+#include "eti-processor.h"
 
 const char* fftPlacementMethodToString(FFTPlacementMethod fft_placement);
 const char* freqSyncMethodToString(FreqsyncMethod method);
@@ -109,10 +110,13 @@ class RadioReceiver {
                 bool unique);
 
         DABParams params; // Defaults to TM1 parameters
+        InputInterface& input;
 
         MscHandler mscHandler;
         FicHandler ficHandler;
         OFDMProcessor ofdmProcessor;
+        // AI: ETIProcessor replaces OFDMProcessor when input.isEtiInput() is true.
+        ETIProcessor etiProcessor;
 };
 
 #endif

--- a/src/input/eti_file.cpp
+++ b/src/input/eti_file.cpp
@@ -1,0 +1,290 @@
+/*
+ *    Copyright (C) 2026
+ *
+ *    This file is part of the welle.io.
+ *
+ *    AI-generated: see eti_file.h for design notes.
+ */
+
+#include "eti_file.h"
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <cerrno>
+
+CETIFile::CETIFile(RadioControllerInterface& radioController) :
+    radioController(radioController)
+{
+}
+
+CETIFile::~CETIFile(void)
+{
+    stop();
+}
+
+void CETIFile::setFileName(const std::string& fileName)
+{
+    this->fileName = fileName;
+    (void)restart();
+}
+
+void CETIFile::setFrequency(int frequency)
+{
+    (void)frequency;
+}
+
+int CETIFile::getFrequency() const
+{
+    return 0;
+}
+
+bool CETIFile::openFile()
+{
+    stop();
+
+    if (fileName.empty()) {
+        ok = false;
+        return false;
+    }
+
+    peekedBytes.clear();
+    peekedPos = 0;
+
+    if (fileName == "-") {
+        // Read from stdin
+        fd = stdin;
+        isStdin = true;
+    }
+    else {
+        isStdin = false;
+        fd = fopen(fileName.c_str(), "rb");
+        if (!fd) {
+            ok = false;
+            std::clog << "ETIFile: Cannot open file: " << fileName << std::endl;
+            return false;
+        }
+    }
+
+    if (!identifyStreamType()) {
+        if (!isStdin) {
+            fclose(fd);
+        }
+        fd = nullptr;
+        ok = false;
+        radioController.onMessage(message_level_t::Error,
+                "Unknown ETI stream format");
+        return false;
+    }
+
+    ok = true;
+    return true;
+}
+
+bool CETIFile::identifyStreamType()
+{
+    // The upstream tool (dab2eti, eti-cmdline, ...) may already be mid-frame
+    // when we first read from the pipe.  Scan forward up to one full ETI frame
+    // length (6144 bytes) looking for a valid sync word, then treat everything
+    // from that sync word onward as the beginning of the stream.
+    const size_t kMaxScan = 6144 + 64; // a little past one frame
+    std::vector<uint8_t> scan;
+    scan.reserve(kMaxScan);
+
+    // Read scan bytes in chunks.
+    {
+        uint8_t chunk[512];
+        while (scan.size() < kMaxScan) {
+            const size_t want = std::min(sizeof(chunk), kMaxScan - scan.size());
+            const size_t got  = fread(chunk, 1, want, fd);
+            if (got == 0) break;
+            scan.insert(scan.end(), chunk, chunk + got);
+
+            // Check for sync at any position seen so far.
+            const size_t end = scan.size();
+            for (size_t i = 0; i + 4 <= end; i++) {
+                if (!isRawSync(scan.data() + i)) continue;
+
+                // Found a sync word at offset i.
+                streamType = StreamType::Raw;
+
+                if (i > 0) {
+                    std::clog << "ETIFile: sync found at byte offset " << i
+                              << ", skipped " << i << " prefix bytes" << std::endl;
+                }
+
+                // For a seekable file seek to the sync position;
+                // for a pipe store everything from the sync onward in the peek buffer.
+                if (fseek(fd, static_cast<long>(i), SEEK_SET) != 0) {
+                    // Not seekable — store tail bytes for replay.
+                    peekedBytes.assign(scan.begin() + i, scan.end());
+                    peekedPos = 0;
+                }
+                return true;
+            }
+        }
+    }
+
+    // No sync found — log the first bytes to help diagnose the format.
+    std::clog << "ETIFile: no ETI sync found in " << scan.size() << " bytes. First bytes (hex):";
+    for (size_t i = 0; i < std::min(scan.size(), (size_t)24); i++) {
+        char buf[4];
+        std::snprintf(buf, sizeof(buf), " %02x", scan[i]);
+        std::clog << buf;
+    }
+    std::clog << std::endl;
+    return false;
+}
+
+// Helper: read n bytes, draining the peek buffer first.
+size_t CETIFile::readBytes(uint8_t* buf, size_t n)
+{
+    size_t filled = 0;
+
+    // Drain peeked bytes first.
+    if (peekedPos < peekedBytes.size()) {
+        const size_t avail = peekedBytes.size() - peekedPos;
+        const size_t take  = std::min(avail, n);
+        std::memcpy(buf, peekedBytes.data() + peekedPos, take);
+        peekedPos += take;
+        filled    += take;
+    }
+
+    if (filled < n) {
+        filled += fread(buf + filled, 1, n - filled, fd);
+    }
+
+    return filled;
+}
+
+bool CETIFile::isRawSync(const uint8_t *buf) const
+{
+    if (!buf || buf[0] != 0xFF) {
+        return false;
+    }
+
+    const bool fsyncA = (buf[1] == 0xF8 && buf[2] == 0xC5 && buf[3] == 0x49);
+    const bool fsyncB = (buf[1] == 0x07 && buf[2] == 0x3A && buf[3] == 0xB6);
+    return fsyncA || fsyncB;
+}
+
+bool CETIFile::restart(void)
+{
+    return openFile();
+}
+
+bool CETIFile::is_ok()
+{
+    return ok;
+}
+
+void CETIFile::stop(void)
+{
+    if (fd && !isStdin) {
+        fclose(fd);
+    }
+    fd = nullptr;
+    ok = false;
+}
+
+void CETIFile::reset()
+{
+    if (!isStdin && fd) {
+        fseek(fd, 0, SEEK_SET);
+    }
+}
+
+int32_t CETIFile::getSamples(DSPCOMPLEX* v, int32_t size)
+{
+    (void)v;
+    (void)size;
+    return 0;
+}
+
+std::vector<DSPCOMPLEX> CETIFile::getSpectrumSamples(int size)
+{
+    return std::vector<DSPCOMPLEX>(static_cast<size_t>(std::max(0, size)), DSPCOMPLEX(0.0f, 0.0f));
+}
+
+int32_t CETIFile::getSamplesToRead(void)
+{
+    return 0;
+}
+
+float CETIFile::getGain() const
+{
+    return 0.0f;
+}
+
+float CETIFile::setGain(int gain)
+{
+    (void)gain;
+    return 0.0f;
+}
+
+int CETIFile::getGainCount()
+{
+    return 0;
+}
+
+void CETIFile::setAgc(bool agc)
+{
+    (void)agc;
+}
+
+std::string CETIFile::getDescription()
+{
+    return isStdin ? "eti_file (stdin)" : "eti_file (" + fileName + ")";
+}
+
+CDeviceID CETIFile::getID()
+{
+    return CDeviceID::ETI_FILE;
+}
+
+bool CETIFile::isEtiInput(void) const
+{
+    return true;
+}
+
+int32_t CETIFile::getEtiFrame(uint8_t* buffer, size_t size)
+{
+    if (!fd || !buffer || size < 6144) {
+        return -1;
+    }
+
+    memset(buffer, 0x55, size);
+
+    if (streamType == StreamType::Raw) {
+        const size_t got = readBytes(buffer, 6144);
+        if (got == 0) {
+            return 0;
+        }
+        if (got != 6144) {
+            return -1;
+        }
+        return 6144;
+    }
+
+    if (streamType == StreamType::Streamed) {
+        uint8_t lenBytes[2];
+        if (readBytes(lenBytes, 2) != 2) {
+            return 0;
+        }
+
+        const uint16_t frameSize = static_cast<uint16_t>(lenBytes[0]) |
+            (static_cast<uint16_t>(lenBytes[1]) << 8);
+        if (frameSize == 0 || frameSize > 6144) {
+            return -1;
+        }
+
+        const size_t got = readBytes(buffer, frameSize);
+        if (got != frameSize) {
+            return -1;
+        }
+
+        return frameSize;
+    }
+
+    return -1;
+}

--- a/src/input/eti_file.h
+++ b/src/input/eti_file.h
@@ -1,0 +1,76 @@
+/*
+ *    Copyright (C) 2026
+ *
+ *    This file is part of the welle.io.
+ *
+ *    AI-generated: CVirtualInput implementation for raw ETI-NI files and
+ *    pipes (including stdin via "-").  Handles two on-disk formats:
+ *      - Raw   : 6144-byte frames, sync word FF F8 C5 49 / FF 07 3A B6 at byte 0
+ *      - Streamed : 2-byte LE frame-length prefix followed by the frame
+ *    For non-seekable sources (pipes, /dev/stdin) the bytes consumed during
+ *    format detection are saved in a replay buffer (peekedBytes).
+ */
+
+#ifndef ETI_FILE_H
+#define ETI_FILE_H
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "virtual_input.h"
+
+class CETIFile : public CVirtualInput
+{
+public:
+    CETIFile(RadioControllerInterface& radioController);
+    ~CETIFile(void) override;
+
+    void setFileName(const std::string& fileName);
+
+    void setFrequency(int frequency) override;
+    int getFrequency() const override;
+    bool restart(void) override;
+    bool is_ok() override;
+    void stop(void) override;
+    void reset() override;
+    int32_t getSamples(DSPCOMPLEX* v, int32_t size) override;
+    std::vector<DSPCOMPLEX> getSpectrumSamples(int size) override;
+    int32_t getSamplesToRead(void) override;
+    float getGain() const override;
+    float setGain(int gain) override;
+    int getGainCount() override;
+    void setAgc(bool agc) override;
+    std::string getDescription() override;
+    CDeviceID getID() override;
+
+    bool isEtiInput(void) const override;
+    int32_t getEtiFrame(uint8_t* buffer, size_t size) override;
+
+private:
+    enum class StreamType {
+        None,
+        Raw,
+        Streamed,
+    };
+
+    bool openFile();
+    bool identifyStreamType();
+    bool isRawSync(const uint8_t *buf) const;
+
+    RadioControllerInterface& radioController;
+    std::string fileName;
+    FILE *fd = nullptr;
+    bool ok = false;
+    bool isStdin = false;
+    StreamType streamType = StreamType::None;
+
+    // Bytes from stream-type detection that must be replayed before further reads.
+    // Uses a vector so it can hold the full scan tail (up to ~6144 bytes).
+    std::vector<uint8_t> peekedBytes;
+    size_t peekedPos = 0;
+
+    size_t readBytes(uint8_t* buf, size_t n);
+};
+
+#endif

--- a/src/input/input_factory.cpp
+++ b/src/input/input_factory.cpp
@@ -39,6 +39,8 @@
 #include "null_device.h"
 #include "rtl_tcp.h"
 #include "raw_file.h"
+// AI: ETI file device.
+#include "eti_file.h"
 
 #ifdef HAVE_RTLSDR
 #include "rtl_sdr.h"
@@ -101,6 +103,7 @@ CVirtualInput *CInputFactory::GetDevice(RadioControllerInterface &radioControlle
         case CDeviceID::RTL_SDR: InputDevice = new CRTL_SDR(radioController); break;
 #endif
         case CDeviceID::RAWFILE: InputDevice = new CRAWFile(radioController); break;
+        case CDeviceID::ETI_FILE: InputDevice = new CETIFile(radioController); break;
 #ifdef HAVE_SOAPYSDR
         case CDeviceID::SOAPYSDR: InputDevice = new CSoapySdr(radioController); break;
 #endif
@@ -200,6 +203,8 @@ CVirtualInput* CInputFactory::GetManualDevice(RadioControllerInterface& radioCon
 #endif
         if (device == "rawfile")
             InputDevice = new CRAWFile(radioController);
+        else if (device == "eti_file")
+            InputDevice = new CETIFile(radioController);
         else
             std::clog << "InputFactory:"
                 "Unknown device \"" << device << "\"." << std::endl;

--- a/src/input/virtual_input.h
+++ b/src/input/virtual_input.h
@@ -38,8 +38,9 @@
 #include "radio-controller.h"
 #include "ringbuffer.h"
 
+// AI: ETI_FILE added for the CETIFile input device.
 enum class CDeviceID {
-    UNKNOWN, NULLDEVICE, AIRSPY, RAWFILE, RTL_SDR, RTL_TCP, SOAPYSDR, ANDROID_RTL_SDR, LIMESDR};
+    UNKNOWN, NULLDEVICE, AIRSPY, RAWFILE, ETI_FILE, RTL_SDR, RTL_TCP, SOAPYSDR, ANDROID_RTL_SDR, LIMESDR};
 
 class CVirtualInput : public InputInterface {
 public:

--- a/src/various/Socket.cpp
+++ b/src/various/Socket.cpp
@@ -32,6 +32,7 @@
 
 #include <stdexcept>
 #include <iostream>
+#include <cerrno>
 #include <cstring>
 #include "various/Socket.h"
 
@@ -167,7 +168,9 @@ Socket Socket::accept()
     socklen_t remote_addr_len = sizeof(remote_addr);
     int conn = ::accept(sock, (sockaddr*)&remote_addr, &remote_addr_len);
     if (conn == -1) {
-        if (errno == ECONNABORTED) {
+        // AI: EINTR is expected when SIGINT is caught during accept();
+        // return an invalid socket so serve() can exit the loop cleanly.
+        if (errno == EINTR) {
             return {};
         }
         perror("accept failed");

--- a/src/welle-cli/index.html
+++ b/src/welle-cli/index.html
@@ -24,7 +24,7 @@ body {
     line-height: 1.6;
     min-height: 100vh;
     -webkit-text-size-adjust: 100%;
-}
+    overflow-x: hidden; /* Hiding page-level x overflow */
 
 a {
     color: #6ea8fe;
@@ -54,6 +54,26 @@ h2 {
     max-width: 1100px;
     margin: 0 auto;
     padding: 24px 20px;
+}
+
+@media (max-width: 1200px) {
+    .app-container {
+        padding: 20px 14px;
+    }
+    .servicetable-scroll {
+        padding: 0 12px;
+    }
+    table#servicetable th,
+    table#servicetable td {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
+    th#dls {
+        width: 320px;
+    }
+    th#techdetails {
+        width: 190px;
+    }
 }
 
 .app-header {
@@ -173,6 +193,25 @@ input[type="checkbox"] {
 }
 #ensembleinfo {
     margin-bottom: 20px;
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    overflow-x: visible;
+}
+
+.servicetable-scroll {
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100dvw;
+    max-width: 100dvw;
+    padding: 0 20px;
+    box-sizing: border-box;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
 }
 
 #mux-info h1 {
@@ -196,11 +235,14 @@ table, th, td {
     border-collapse: collapse;
 }
 table#servicetable {
-    width: 100%;
+    width: max(100%, 1160px);
+    table-layout: auto;
+    box-sizing: border-box;
+    margin-left: 0;
     border-collapse: separate;
     border-spacing: 0;
     border-radius: 12px;
-    overflow: hidden;
+    overflow: visible;
     margin-bottom: 16px;
     border: 1px solid #2a2d3a;
 }
@@ -216,13 +258,22 @@ table#servicetable th {
     border-bottom: 2px solid #2a2d3a;
 }
 th#dls {
-    width: 300px;
+    width: 380px;
+}
+th#techdetails {
+    width: 220px;
+}
+th#playeraudio {
+    width: 150px;
 }
 table#servicetable td {
     padding: 12px 14px;
     font-size: 15px;
     border-bottom: 1px solid #1e2130;
     vertical-align: middle;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 table#servicetable tr:nth-child(even) {
     background-color: #151821;
@@ -232,6 +283,59 @@ table#servicetable tr:nth-child(odd) {
 }
 table#servicetable tr:hover {
     background-color: #1c1f2e;
+}
+
+table#servicetable tr.cu-summary-row {
+    background: #171a24;
+}
+table#servicetable tr.cu-summary-row:hover {
+    background: #171a24;
+}
+table#servicetable tr.cu-summary-row td {
+    border-bottom: none;
+    font-size: 14px;
+    color: #aeb6ce;
+    font-weight: 600;
+}
+
+/* Service table: player + audio stacked in one column */
+.player-audio-cell {
+    min-width: 128px;
+    padding: 8px 10px !important;
+}
+.player-audio-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    align-items: flex-start;
+}
+.audio-level-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    width: 100%;
+    line-height: 1;
+}
+.audio-level-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    line-height: 1;
+}
+.audio-level-row .audio-ch {
+    width: 10px;
+    font-size: 11px;
+    font-weight: 700;
+    color: #9aa0b8;
+    text-transform: uppercase;
+    line-height: 1;
+}
+.audio-level-row canvas {
+    width: 80px;
+    height: 7px;
+    border: none;
+    border-radius: 5px;
+    background: #1a1d28;
 }
 
 /* ── Stats table (Ensemble ID, ECC…) card style ─── */
@@ -338,9 +442,9 @@ button[onclick="stopPlayer()"]::before {
     vertical-align: middle;
 }
 .sls-thumb {
-    width: 70px;
-    height: 70px;
-    object-fit: cover;
+    width: auto;
+    height: 72px;
+    object-fit: contain;
     border-radius: 6px;
     cursor: pointer;
     border: 1px solid #3a3d50;
@@ -597,17 +701,12 @@ canvas {
 /* ── Responsive - Mobile ─────────────────────────── */
 @media (max-width: 900px),
        (orientation: landscape) and (max-height: 600px) and (pointer: coarse) {
-    html {
-        overflow-x: hidden;
-    }
     body {
         font-size: 15px;
-        overflow-x: hidden;
-        max-width: 100vw;
+        max-width: 100%;
     }
     .app-container {
         padding: 14px 12px;
-        overflow-x: hidden;
     }
     .app-header {
         flex-direction: column;
@@ -774,6 +873,28 @@ canvas {
     }
 
     /* ── Services table: CARD LAYOUT ─────────────── */
+    #ensembleinfo {
+        width: 100%;
+        max-width: 100%;
+        position: static;
+        left: auto;
+        transform: none;
+        margin-left: 0;
+        margin-right: 0;
+        padding: 0;
+        overflow-x: visible;
+    }
+    .servicetable-scroll {
+        position: static;
+        left: auto;
+        transform: none;
+        width: 100%;
+        max-width: 100%;
+        padding: 0;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+
     #ensembleinfo table {
         display: flex;
         flex-direction: column;
@@ -787,11 +908,28 @@ canvas {
     #ensembleinfo table tr:first-child {
         display: none;
     }
+    #ensembleinfo table tr.cu-summary-row {
+        display: flex;
+        background: #171a24;
+    }
+    #ensembleinfo table tr.cu-summary-row:hover {
+        background: #171a24;
+    }
+    #ensembleinfo table tr.cu-summary-row td {
+        display: block;
+        flex: 1 1 100%;
+        font-size: 14px;
+        color: #aeb6ce;
+        font-weight: 600;
+        border: none;
+        padding: 0;
+        margin: 0;
+    }
     /* Each service row becomes a card */
     #ensembleinfo table tr {
         display: flex;
         flex-wrap: wrap;
-        align-items: center;
+        align-items: stretch;
         width: 100%;
         box-sizing: border-box;
         background: #1a1d28;
@@ -812,27 +950,31 @@ canvas {
     }
     /* Col 1: Station name - top left, takes most width */
     #ensembleinfo table td:nth-child(1) {
-        flex: 1 1 55%;
-        font-weight: 600;
+        flex: 1 1 100%;
+        font-weight: 700;
         font-size: 16px;
         color: #f0f0f5;
         min-width: 0;
         word-break: break-word;
+        padding-bottom: 8px;
+        margin-bottom: 6px;
+        border-bottom: 1px solid #2a2d3a;
     }
-    /* Col 12: Play button - top right */
-    #ensembleinfo table td:nth-child(12) {
+    /* Col 11: Play + audio below header */
+    #ensembleinfo table td:nth-child(11) {
         flex: 0 0 auto;
-        order: -1;
-        margin-left: auto;
+        order: 2;
+        margin-left: 0;
+        align-self: flex-start;
     }
-    /* Col 13: SLS thumbnail - full width at bottom */
-    #ensembleinfo table td:nth-child(13) {
+    /* Col 12: SLS thumbnail - full width at bottom */
+    #ensembleinfo table td:nth-child(12) {
         flex: 1 1 100%;
         order: 4;
         display: flex;
         justify-content: center;
     }
-    #ensembleinfo table td:nth-child(13) .sls-thumb {
+    #ensembleinfo table td:nth-child(12) .sls-thumb {
         width: 100%;
         height: auto;
         max-height: 180px;
@@ -850,16 +992,15 @@ canvas {
         order: 3;
         min-height: 0;
     }
-    /* Hide non-essential columns:
-       col2=SId, col4=CU, col5=Prot, col6=Tech, col7=PTy, col8=Lang, col10=Errors, col11=AudioLevel */
+     /* Hide non-essential columns:
+         col2=SId, col4=CU, col5=Prot, col6=Tech, col7=PTy, col8=Lang, col10=Errors */
     #ensembleinfo table td:nth-child(2),
     #ensembleinfo table td:nth-child(4),
     #ensembleinfo table td:nth-child(5),
     #ensembleinfo table td:nth-child(6),
     #ensembleinfo table td:nth-child(7),
     #ensembleinfo table td:nth-child(8),
-    #ensembleinfo table td:nth-child(10),
-    #ensembleinfo table td:nth-child(11) {
+     #ensembleinfo table td:nth-child(10) {
         display: none;
     }
 

--- a/src/welle-cli/index.html
+++ b/src/welle-cli/index.html
@@ -929,8 +929,8 @@ canvas {
 
             <div class="header-card">
                 <div class="controls-bar">
-                    <div class="control-group">
-                        <label for="channelselector">Channel</label>
+                    <!-- AI: id added so applyReceptionMode() can hide this in ETI mode -->
+                    <div class="control-group" id="channelControlGroup">
                         <div class="channel-ctrl">
                             <select id="channelselector" name="channel"></select>
                             <button type="button" class="advanced-toggle" id="advancedToggle" title="Réglages avancés">Param. ⚙</button>

--- a/src/welle-cli/index.js
+++ b/src/welle-cli/index.js
@@ -245,27 +245,26 @@ function muxHeaderTemplate(isLiveRf) {
 }
 
 function ensembleInfoTemplate() {
-    var html = '<table id="servicetable">';
+    var html = '<div class="servicetable-scroll"><table id="servicetable">';
     html += '<tr><th>FIG1 Label (Short label)<br>FIG2 Label</th> ';
     html += '<th><abbr title="Service ID">SId</abbr></th> ';
     html += '<th>Bitrate</th> <th><abbr title="Start CU Address, used CUs">CU info</abbr></th> ';
     html += '<th><abbr title="Protection level">Prot.Lev.</abbr></th>';
-    html += '<th><abbr title="Transmission Mode, rate, channels">Technical details</abbr></th>';
+    html += '<th id="techdetails"><abbr title="Codec profile, channel mode and sampling rate">Technical details</abbr></th>';
     html += '<th><abbr title="Programme type">PTy</abbr></th>';
     html += '<th><abbr title="Service language, Subchannel language">Languages</abbr></th> <th id="dls">DLS</th>';
     html += '<th><abbr title="Frame, Reed Solomon, AAC errors">Errors</abbr></th>';
-    html += '<th><abbr title="red: right, black: left">Audio Level</abbr></th> <th></th><th></th></tr>';
-    html += '${services}</table>';
+    html += '<th id="playeraudio"><abbr title="Play control with stereo audio levels (L/R)">Player / Audio</abbr></th><th>SLS</th></tr>';
+    html += '${services}${freecurow}</table></div>';
     return html;
 }
 
 function serviceTemplate() {
-    var html = '<tr><td><span class="label-desktop">${label} (${shortlabel})<br>${fig2label}</span><span class="label-mobile">${mobilelabel}</span></td> <td>${SId}</td> <td>${bitrate}&nbsp;kbps</td> <td>${sad_cu}</td> <td>${protection}</td>';
+    var html = '<tr><td><span class="label-desktop">${label}<br>(${shortlabel})<br>${fig2label}</span><span class="label-mobile">${mobilelabel}</span></td> <td>${SId}</td> <td>${bitrate}&nbsp;kbps</td> <td>${sad_cu}</td> <td>${protection}</td>';
     html += '<td>${techdetails}</td>';
     html += '<td>${pty}</td> <td>${language}<br>${subchannel_language}</td> <td><i>${dls}</i></td>';
     html += '<td>${errorcounters}</td>';
-    html += '<td><canvas id="${canvasid}" width="64" height="12"></canvas></td>';
-    html += '<td>${playbutton}</td>';
+    html += '<td class="player-audio-cell">${playeraudio}</td>';
     html += '<td class="sls-cell"><img id="sls-${sid}" class="sls-thumb" src="${slssrc}" alt="" onclick="showSlide(${sid_num}, ${mot_time})" style="${slsvisible}"></td>';
     html += '</tr>';
     return html;
@@ -400,9 +399,14 @@ function buildSNRWidget(snr) {
 function drawAudiolevels(services) {
     for (key in services) {
         var service = services[key];
-        var id = "canvas" + service.sid;
-        var canvas = document.getElementById(id);
-        var ctx = canvas.getContext("2d");
+        var canvasL = document.getElementById("canvasL" + service.sid);
+        var canvasR = document.getElementById("canvasR" + service.sid);
+        if (!canvasL || !canvasR) {
+            continue;
+        }
+
+        var ctxL = canvasL.getContext("2d");
+        var ctxR = canvasR.getContext("2d");
 
         var level_db_l = -90;
         var level_db_r = -90;
@@ -415,18 +419,27 @@ function drawAudiolevels(services) {
             }
 
             var last_update = new Date(service.audiolevel.time * 1000);
-            canvas.setAttribute("title", "Updated " + last_update);
+            var tooltip = "Updated " + last_update;
+            canvasL.setAttribute("title", tooltip);
+            canvasR.setAttribute("title", tooltip);
         }
 
-        var width_l = (level_db_l + 90) * 64/90;
-        var width_r = (level_db_r + 90) * 64/90;
+        var width_l = (level_db_l + 90) * canvasL.width / 90;
+        var width_r = (level_db_r + 90) * canvasR.width / 90;
 
-        var height = canvas.height / 2;
+        ctxL.clearRect(0, 0, canvasL.width, canvasL.height);
+        ctxR.clearRect(0, 0, canvasR.width, canvasR.height);
 
-        ctx.fillStyle = "#444444";
-        ctx.fillRect(0,0,width_l,height);
-        ctx.fillStyle = "#DD4444";
-        ctx.fillRect(0,height,width_r,2*height);
+        ctxL.fillStyle = "#283043";
+        ctxL.fillRect(0, 0, canvasL.width, canvasL.height);
+        ctxR.fillStyle = "#283043";
+        ctxR.fillRect(0, 0, canvasR.width, canvasR.height);
+
+        ctxL.fillStyle = "#22d3ee";
+        ctxL.fillRect(0, 0, width_l, canvasL.height);
+
+        ctxR.fillStyle = "#f59e0b";
+        ctxR.fillRect(0, 0, width_r, canvasR.height);
     }
 };
 
@@ -471,10 +484,12 @@ function populateEnsembleinfo() {
         }
 
         var servicehtml = "";
+        var cuBySubchannel = {};
         for (ix in start_addresses) {
             var key = start_addresses[ix].key;
             var service = data.services[key];
             var s = {};
+            var hasAudioComponent = false;
             s["label"] = service.label.label;
             s["fig2label"] = service.label.fig2label;
             s["shortlabel"] = service.label.shortlabel;
@@ -490,11 +505,83 @@ function populateEnsembleinfo() {
                 s["protection"] = sub.protection;
                 s["subchannel_language"] = sub.languagestring;
 
+                for (var cix in service.components) {
+                    var comp = service.components[cix];
+                    if (comp.subchannel && comp.subchannel.subchid !== undefined && comp.subchannel.cu !== undefined) {
+                        cuBySubchannel[String(comp.subchannel.subchid)] = comp.subchannel.cu;
+                    }
+                }
+
                 if (sc.transportmode == "audio") {
-                    s["techdetails"] = sc.ascty + ", " +
-                        service.samplerate + " Hz, " +
-                        service.mode + ", " +
-                        service.channels;
+                    hasAudioComponent = true;
+                    var rawAscty = (sc.ascty || "").trim();
+                    var formatSummary = (service.mode || "").trim();
+                    var codecSource = formatSummary || rawAscty;
+                    var codecLabel = "";
+                    var isHeAacV2 = /HE-AAC\s*v?\s*2/i.test(codecSource);
+
+                    if (isHeAacV2) {
+                        codecLabel = "DAB+/HE-AACv2";
+                    }
+                    else if (/HE-AAC/i.test(codecSource)) {
+                        codecLabel = "DAB+/HE-AAC";
+                    }
+                    else if (/AAC-LC/i.test(codecSource)) {
+                        codecLabel = "DAB+/AAC-LC";
+                    }
+                    else if (/\bDAB\+\b/i.test(rawAscty)) {
+                        codecLabel = "DAB+";
+                    }
+                    else {
+                        codecLabel = rawAscty
+                            .replace(/\s*@\s*.*$/, "")
+                            .replace(/\b\d+(?:\.\d+)?\s*k?Hz\b/ig, "")
+                            .replace(/\b\d+(?:\.\d+)?\s*kbit\/s\b/ig, "")
+                            .replace(/\b(?:mono|stereo|parametric\s+stereo)\b/ig, "")
+                            .replace(/\s+/g, " ")
+                            .trim();
+                    }
+
+                    var normalizeMode = function(modeText) {
+                        var m = (modeText || "").toString().trim();
+                        if (!m || /^invalid$/i.test(m)) {
+                            return "";
+                        }
+                        if (/parametric\s+stereo/i.test(m)) {
+                            return "Parametric Stereo";
+                        }
+                        if (/\bmono\b/i.test(m)) {
+                            return "Mono";
+                        }
+                        if (/\bstereo\b/i.test(m)) {
+                            return "Stereo";
+                        }
+                        return "";
+                    };
+
+                    var modeLabel = normalizeMode(service.mode);
+
+                    if (!modeLabel) {
+                        modeLabel = normalizeMode(codecSource);
+                    }
+
+                    if (isHeAacV2 && modeLabel !== "Mono") {
+                        modeLabel = "Parametric Stereo";
+                    }
+
+                    var samplerateKhz = "";
+                    if (service.samplerate) {
+                        if (service.samplerate % 1000 === 0) {
+                            samplerateKhz = (service.samplerate / 1000) + "kHz";
+                        }
+                        else {
+                            samplerateKhz = (service.samplerate / 1000).toFixed(1) + "kHz";
+                        }
+                    }
+
+                    s["techdetails"] = [codecLabel, modeLabel, samplerateKhz].filter(function(v) {
+                        return !!v;
+                    }).join(" ");
                     s["buttondisabled"] = "";
                     s["buttonclass"] = "";
                 }
@@ -528,7 +615,8 @@ function populateEnsembleinfo() {
 
             s["pty"] = service.ptystring;
             s["language"] = service.languagestring;
-            s["canvasid"] = "canvas" + service.sid;
+            s["canvasid_l"] = "canvasL" + service.sid;
+            s["canvasid_r"] = "canvasR" + service.sid;
 
             if (service.errorcounters) {
                 s["errorcounters"] = service.errorcounters.frameerrors + "," +
@@ -545,6 +633,17 @@ function populateEnsembleinfo() {
                 s["playbutton"] = '<button type=button onclick="setPlayerSource(' + service.sid + ')">Play</button>';
             } else {
                 s["playbutton"] = '<button type=button disabled class="disabled">Play</button>';
+            }
+
+            if (hasAudioComponent) {
+                s["playeraudio"] = '<div class="player-audio-stack">' + s["playbutton"] +
+                    '<div class="audio-level-wrap" title="Stereo audio level in dBFS">' +
+                    '<div class="audio-level-row"><span class="audio-ch">L</span><canvas id="' + s["canvasid_l"] + '" width="80" height="7"></canvas></div>' +
+                    '<div class="audio-level-row"><span class="audio-ch">R</span><canvas id="' + s["canvasid_r"] + '" width="80" height="7"></canvas></div>' +
+                    '</div></div>';
+            }
+            else {
+                s["playeraudio"] = '';
             }
 
             var cached = slsCache[service.sid];
@@ -591,6 +690,18 @@ function populateEnsembleinfo() {
         ens["hw_name"] = data.receiver.hardware.name;
         ens["sw_name"] = data.receiver.software.name;
         ens["services"] = servicehtml;
+
+        var usedCu = 0;
+        for (var subch in cuBySubchannel) {
+            if (Object.prototype.hasOwnProperty.call(cuBySubchannel, subch)) {
+                usedCu += cuBySubchannel[subch];
+            }
+        }
+        var totalCu = 864;
+        var freeCu = Math.max(0, totalCu - usedCu);
+        ens["freecurow"] = '<tr class="cu-summary-row"><td colspan="12">Free CUs: ' + freeCu +
+            ' (used: ' + usedCu + '/' + totalCu + ')</td></tr>';
+
         ens["ficcrcerrors"] = data.demodulator.fic.numcrcerrors;
         var lcc = new Date(data.receiver.software.lastchannelchange);
         ens["lastchannelchange"] = lcc.toISOString();

--- a/src/welle-cli/index.js
+++ b/src/welle-cli/index.js
@@ -170,36 +170,77 @@ var currentPlayingSid = null;
 var currentSlideSid = null;
 var currentSlideLastUpdate = 0;
 var slsCache = {}; // sid -> {time, blobUrl} — slide images stored as local blob URLs
+var liveRfMode = true;
 
-function muxHeaderTemplate() {
+function applyReceptionMode(isLiveRf) {
+    liveRfMode = isLiveRf;
+
+    var advancedControls = document.getElementById('advancedControls');
+    var advancedToggle = document.getElementById('advancedToggle');
+    var channelControlGroup = document.getElementById('channelControlGroup');
+    var blockSpectrum = document.getElementById('block_spectrum');
+    var blockCir = document.getElementById('block_cir');
+    var blockConstellation = document.getElementById('block_constellation');
+    var blockTii = document.getElementById('block_tii');
+
+    var display = isLiveRf ? '' : 'none';
+    if (advancedControls) advancedControls.style.display = display;
+    if (advancedToggle) advancedToggle.style.display = display;
+    if (channelControlGroup) channelControlGroup.style.display = display;
+    if (blockSpectrum) blockSpectrum.style.display = display;
+    if (blockCir) blockCir.style.display = display;
+    if (blockConstellation) blockConstellation.style.display = display;
+    if (blockTii) blockTii.style.display = display;
+}
+
+function muxHeaderTemplate(isLiveRf) {
     var html = '';
     html += '<h1 class="ens-ps8"><abbr title="Ensemble long and short labels defined in FIG1">${label} (${shortlabel})</abbr></h1>';
     html += '<h2 class="ens-ps16"><abbr title="Ensemble long and short labels defined in FIG2">${fig2label}</abbr></h2>';
     html += '<div class="ens-mobile-name">${mobilelabel_ens}</div>';
     html += '<table class="stats-table">';
-    html += '<tr><th>Ensemble ID</th>';
-    html += '<th>ECC</th>';
-    html += '<th>SNR</th>';
-    html += '<th>RX gain</th>';
-    html += '<th>Freq corr</th>';
-    html += '<th>Date</th>';
-    html += '<th><abbr title="Local Time Offset">LTO</abbr></th>';
-    html += '<th>FIC CRC Errors</th>';
-    html += '<th>Tuned at</th>';
-    html += '<th>FCT0 frame received at</th>';
-    html += '</tr>';
-    html += '<tr><td>${EId}</td>';
-    html += '<td>${ecc}</td>';
-    html += '<td>${SNR}</td>';
-    html += '<td>${gain}</td>';
-    html += '<td>${FrequencyCorrection}</td>';
-    html += '<td>${year}-${month}-${day} ${hour}:${minutes} UTC</td>';
-    html += '<td>${lto}</td>';
-    html += '<td>${ficcrcerrors}</td>';
-    html += '<td>${lastchannelchange}</td>';
-    html += '<td>${lastfct0frame}</td></tr>';
+    if (isLiveRf) {
+        html += '<tr><th>Ensemble ID</th>';
+        html += '<th>ECC</th>';
+        html += '<th>SNR</th>';
+        html += '<th>RX gain</th>';
+        html += '<th>Freq corr</th>';
+        html += '<th>Date</th>';
+        html += '<th><abbr title="Local Time Offset">LTO</abbr></th>';
+        html += '<th>FIC CRC Errors</th>';
+        html += '<th>Tuned at</th>';
+        html += '<th>FCT0 frame received at</th>';
+        html += '</tr>';
+        html += '<tr><td>${EId}</td>';
+        html += '<td>${ecc}</td>';
+        html += '<td>${SNR}</td>';
+        html += '<td>${gain}</td>';
+        html += '<td>${FrequencyCorrection}</td>';
+        html += '<td>${year}-${month}-${day} ${hour}:${minutes} UTC</td>';
+        html += '<td>${lto}</td>';
+        html += '<td>${ficcrcerrors}</td>';
+        html += '<td>${lastchannelchange}</td>';
+        html += '<td>${lastfct0frame}</td></tr>';
+    }
+    else {
+        html += '<tr><th>Ensemble ID</th>';
+        html += '<th>ECC</th>';
+        html += '<th>Date</th>';
+        html += '<th><abbr title="Local Time Offset">LTO</abbr></th>';
+        html += '<th>FIC CRC Errors</th>';
+        html += '<th>Input</th>';
+        html += '</tr>';
+        html += '<tr><td>${EId}</td>';
+        html += '<td>${ecc}</td>';
+        html += '<td>${year}-${month}-${day} ${hour}:${minutes} UTC</td>';
+        html += '<td>${lto}</td>';
+        html += '<td>${ficcrcerrors}</td>';
+        html += '<td>ETI</td></tr>';
+    }
     html += '</table>';
-    html += '${snr_widget}';
+    if (isLiveRf) {
+        html += '${snr_widget}';
+    }
     return html;
 }
 
@@ -531,46 +572,54 @@ function populateEnsembleinfo() {
         ens["minutes"] = data.utctime.minutes;
         ens["lto"] = data.utctime.lto;
 
-        ens["gain"] = data.receiver.hardware.gain.toFixed(1);
-        document.getElementById("fftwindowselector").value = data.receiver.software.fftwindowplacement;
-        document.getElementById("coarsecheckbox").checked = data.receiver.software.coarsecorrectorenabled;
+        // AI: detect ETI mode from mux.json and hide RF-only controls.
+        var isLiveRf = !data.receiver.software.inputmode || data.receiver.software.inputmode !== "eti";
+        applyReceptionMode(isLiveRf);
+
+        if (isLiveRf) {
+            ens["gain"] = data.receiver.hardware.gain.toFixed(1);
+            document.getElementById("fftwindowselector").value = data.receiver.software.fftwindowplacement;
+            document.getElementById("coarsecheckbox").checked = data.receiver.software.coarsecorrectorenabled;
+            ens["SNR"] = data.demodulator.snr.toFixed(1);
+            ens["snr_widget"] = buildSNRWidget(data.demodulator.snr);
+            ens["FrequencyCorrection"] = data.demodulator.frequencycorrection;
+            var lfct0 = new Date(data.demodulator.time_last_fct0_frame);
+            ens["lastfct0frame"] = lfct0.toISOString();
+        }
 
         ens["version"] = data.receiver.software.version;
         ens["hw_name"] = data.receiver.hardware.name;
         ens["sw_name"] = data.receiver.software.name;
-        ens["SNR"] = data.demodulator.snr.toFixed(1);
-        ens["snr_widget"] = buildSNRWidget(data.demodulator.snr);
-        ens["FrequencyCorrection"] = data.demodulator.frequencycorrection;
         ens["services"] = servicehtml;
         ens["ficcrcerrors"] = data.demodulator.fic.numcrcerrors;
         var lcc = new Date(data.receiver.software.lastchannelchange);
         ens["lastchannelchange"] = lcc.toISOString();
-        var lfct0 = new Date(data.demodulator.time_last_fct0_frame);
-        ens["lastfct0frame"] = lfct0.toISOString();
 
         var muxInfo = document.getElementById('mux-info');
         if (muxInfo) {
-            muxInfo.innerHTML = parseTemplate(muxHeaderTemplate(), ens);
+            muxInfo.innerHTML = parseTemplate(muxHeaderTemplate(isLiveRf), ens);
         }
 
         var ei = document.getElementById('ensembleinfo');
         ei.innerHTML = parseTemplate(ensembleInfoTemplate(), ens);
 
-        tiihtml = "<ul>";
-        var eid = data.ensemble.id.substring(2).toUpperCase();
-        for (key in data.tii) {
-            var tii = data.tii[key];
-            var tii_key = eid + '_' + tii.pattern.toString().padStart(2,'0') + tii.comb.toString().padStart(2,'0');
-            if (!tii_db[tii_key]) continue;
-            tii.site_name = ' \u2014 ' + tii_db[tii_key];
-            tiihtml += parseTemplate(tiiTemplate(), tii);
+        if (isLiveRf) {
+            tiihtml = "<ul>";
+            var eid = data.ensemble.id.substring(2).toUpperCase();
+            for (key in data.tii) {
+                var tii = data.tii[key];
+                var tii_key = eid + '_' + tii.pattern.toString().padStart(2,'0') + tii.comb.toString().padStart(2,'0');
+                if (!tii_db[tii_key]) continue;
+                tii.site_name = ' \u2014 ' + tii_db[tii_key];
+                tiihtml += parseTemplate(tiiTemplate(), tii);
+            }
+            tiihtml += "</ul>";
+
+            var tii_el = document.getElementById('tiiinfo');
+            tii_el.innerHTML = tiihtml;
+
+            drawCIRPeaks(data.cir_peaks);
         }
-        tiihtml += "</ul>";
-
-        var tii_el = document.getElementById('tiiinfo');
-        tii_el.innerHTML = tiihtml;
-
-        drawCIRPeaks(data.cir_peaks);
 
         drawAudiolevels(data.services);
 

--- a/src/welle-cli/jsonconvert.cpp
+++ b/src/welle-cli/jsonconvert.cpp
@@ -53,6 +53,8 @@ static void to_json(nlohmann::json& j, const SoftwareJson& s) {
     j = nlohmann::json{
         {"name", s.name},
         {"version", s.version},
+        // AI: inputmode field distinguishes rf / eti in the web UI.
+        {"inputmode", s.inputmode},
         {"fftwindowplacement", s.fftwindowplacement},
         {"coarsecorrectorenabled", s.coarsecorrectorenabled},
         {"freqsyncmethod", s.freqsyncmethod},

--- a/src/welle-cli/jsonconvert.h
+++ b/src/welle-cli/jsonconvert.h
@@ -36,6 +36,8 @@
 struct SoftwareJson {
     std::string name;
     std::string version;
+    // AI: identifies whether the receiver is in RF or ETI input mode.
+    std::string inputmode;
     std::string fftwindowplacement;
     bool coarsecorrectorenabled = false;
     std::string freqsyncmethod;

--- a/src/welle-cli/webprogrammehandler.cpp
+++ b/src/welle-cli/webprogrammehandler.cpp
@@ -25,6 +25,7 @@
 #include "webprogrammehandler.h"
 #include <iostream>
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
 
 #include <lame/lame.h>
@@ -319,8 +320,14 @@ WebProgrammeHandler::errorcounters_t WebProgrammeHandler::getErrorCounters() con
     return r;
 }
 
+// AI: added console logging to make frame/RS/AAC errors visible on the
+// terminal (they were only counted in mux.json before).
 void WebProgrammeHandler::onFrameErrors(int frameErrors)
 {
+    if (frameErrors > 0) {
+        cerr << "Frame errors 0x" << std::hex << serviceId << std::dec
+             << ": " << frameErrors << endl;
+    }
     std::unique_lock<std::mutex> lock(stats_mutex);
     errorcounters.num_frameErrors += frameErrors;
     errorcounters.time = chrono::system_clock::now();
@@ -339,14 +346,16 @@ void WebProgrammeHandler::onNewAudio(std::vector<int16_t>&& audioData,
     int last_audioLevel_L = 0;
     int last_audioLevel_R = 0;
     {
-        int16_t max_L = 0;
-        int16_t max_R = 0;
+        int32_t max_L = 0;
+        int32_t max_R = 0;
+// AI: use absolute peak per channel so negative excursions are counted too.
         for (size_t i = 0; i < audioData.size()-1; i+=2) {
-            max_L = std::max(max_L, audioData[i]);
-            max_R = std::max(max_R, audioData[i+1]);
+            // Use absolute peak to handle both positive and negative excursions.
+            max_L = std::max(max_L, std::abs(static_cast<int>(audioData[i])));
+            max_R = std::max(max_R, std::abs(static_cast<int>(audioData[i+1])));
         }
-        last_audioLevel_L = max_L;
-        last_audioLevel_R = max_R;
+        last_audioLevel_L = static_cast<int>(max_L);
+        last_audioLevel_R = static_cast<int>(max_R);
     }
 
     {
@@ -378,20 +387,31 @@ void WebProgrammeHandler::onNewAudio(std::vector<int16_t>&& audioData,
 
 }
 
+// AI: erase failed senders immediately so a closed browser tab
+// doesn't block the audio delivery loop on future calls.
 void WebProgrammeHandler::send_to_all_clients(const std::vector<uint8_t>& headerData, const std::vector<uint8_t>& data)
 {
     std::unique_lock<std::mutex> lock(senders_mutex);
 
-    for (auto& s : senders) {
-        bool success = s->send_stream(headerData, data);
+    for (auto it = senders.begin(); it != senders.end(); ) {
+        auto* sender = *it;
+        const bool success = sender->send_stream(headerData, data);
         if (not success) {
-            cerr << "Failed to send audio for " << serviceId << endl;
+            cerr << "Audio client disconnected for service 0x" << std::hex << serviceId << std::dec << endl;
+            it = senders.erase(it);
+        }
+        else {
+            ++it;
         }
     }
 }
 
+// AI: console logging for RS and AAC error callbacks.
 void WebProgrammeHandler::onRsErrors(bool uncorrectedErrors, int numCorrectedErrors)
 {
+    if (uncorrectedErrors) {
+        cerr << "RS uncorrectable error 0x" << std::hex << serviceId << std::dec << endl;
+    }
     (void)numCorrectedErrors; // TODO calculate BER before Reed-Solomon
     std::unique_lock<std::mutex> lock(stats_mutex);
     errorcounters.num_rsErrors += (uncorrectedErrors ? 1 : 0);
@@ -400,6 +420,10 @@ void WebProgrammeHandler::onRsErrors(bool uncorrectedErrors, int numCorrectedErr
 
 void WebProgrammeHandler::onAacErrors(int aacErrors)
 {
+    if (aacErrors > 0) {
+        cerr << "AAC errors 0x" << std::hex << serviceId << std::dec
+             << ": " << aacErrors << endl;
+    }
     std::unique_lock<std::mutex> lock(stats_mutex);
     errorcounters.num_aacErrors += aacErrors;
     errorcounters.time = chrono::system_clock::now();

--- a/src/welle-cli/webradiointerface.cpp
+++ b/src/welle-cli/webradiointerface.cpp
@@ -183,67 +183,68 @@ WebRadioInterface::~WebRadioInterface()
     }
 }
 
-class TuneFailed {};
-
 void WebRadioInterface::check_decoders_required()
 {
     lock_guard<mutex> lock(rx_mut);
     ASSERT_RX;
 
-    try {
-        for (auto& s : rx->getServiceList()) {
-            const auto sid = s.serviceId;
+    for (auto& s : rx->getServiceList()) {
+        const auto sid = s.serviceId;
 
-            try {
-                const bool is_active = find_if(
-                        carousel_services_active.cbegin(),
-                        carousel_services_active.cend(),
-                        [&](const ActiveCarouselService& acs) {
-                            return acs.sid == sid;
-                        }) != carousel_services_active.cend();
+        try {
+            const bool is_active = find_if(
+                    carousel_services_active.cbegin(),
+                    carousel_services_active.cend(),
+                    [&](const ActiveCarouselService& acs) {
+                        return acs.sid == sid;
+                    }) != carousel_services_active.cend();
 
-                const bool require =
-                    rx->serviceHasAudioComponent(s) and
-                    (decode_settings.strategy == DecodeStrategy::All or
-                     phs.at(sid).needsToBeDecoded() or
-                     is_active);
-                const bool is_decoded = programmes_being_decoded[sid];
+            const bool require =
+                rx->serviceHasAudioComponent(s) and
+                (decode_settings.strategy == DecodeStrategy::All or
+                 phs.at(sid).needsToBeDecoded() or
+                 is_active);
+            const bool is_decoded = programmes_being_decoded[sid];
 
-                if (require and not is_decoded) {
-                    bool success = rx->addServiceToDecode(phs.at(sid), "", s);
-
-                    if (success) {
-                        programmes_being_decoded[sid] = success;
-                    }
-                    else {
-                        throw TuneFailed();
-                    }
+            if (require and not is_decoded) {
+                const bool success = rx->addServiceToDecode(phs.at(sid), "", s);
+                if (success) {
+                    programmes_being_decoded[sid] = true;
                 }
-                else if (is_decoded and not require) {
-                    bool success = rx->removeServiceToDecode(s);
-
+                else {
+                    // Service metadata may still be incomplete (e.g. subchannel not yet available).
+                    // Keep state unchanged and retry on next scheduler cycle.
+                    programmes_being_decoded[sid] = false;
+                }
+            }
+            // AI: In ETI mode the FIC data comes from the multiplex itself;
+            // a transient FIC CRC miss can make serviceHasAudioComponent()
+            // momentarily return false even though the service is still
+            // active.  Tearing down the DecoderAdapter on every such glitch
+            // destroys the SuperframeFilter state and causes audible dropouts
+            // (re-sync takes up to 30+ frames = several hundred ms).
+            // Skip automatic removal in ETI mode; decoders are cleaned up
+            // when the receiver stops.
+            else if (is_decoded and not require) {
+                if (input.isEtiInput()) {
+                    // keep decoder alive
+                }
+                else {
+                    const bool success = rx->removeServiceToDecode(s);
                     if (success) {
                         programmes_being_decoded[sid] = false;
                     }
                     else {
                         cerr << "Stop playing 0x" << to_hex(s.serviceId, 4) <<
                             " failed" << endl;
-                        throw TuneFailed();
                     }
                 }
             }
-            catch (const out_of_range&) {
-                cerr << "Cannot tune to 0x" << to_hex(s.serviceId, 4) <<
-                    " because no handler exists!" << endl;
-            }
         }
-    }
-    catch (const TuneFailed&) {
-        rx->restart_decoder();
-        phs.clear();
-        programmes_being_decoded.clear();
-        carousel_services_available.clear();
-        carousel_services_active.clear();
+        catch (const out_of_range&) {
+            cerr << "Cannot tune to 0x" << to_hex(s.serviceId, 4) <<
+                " because no handler exists!" << endl;
+        }
     }
     phs_changed.notify_all();
 }
@@ -662,9 +663,11 @@ static vector<PeakJson> calculate_cir_peaks(const vector<float>& cir_linear)
 bool WebRadioInterface::send_mux_json(Socket& s)
 {
     MuxJson mux_json;
+    const bool is_live_rf = !input.isEtiInput();
 
     mux_json.receiver.software.name = "welle.io";
     mux_json.receiver.software.version = VERSION;
+    mux_json.receiver.software.inputmode = is_live_rf ? "rf" : "eti";
     mux_json.receiver.software.fftwindowplacement = fftPlacementMethodToString(rro.fftPlacementMethod);
     mux_json.receiver.software.coarsecorrectorenabled = not rro.disableCoarseCorrector;
     mux_json.receiver.software.freqsyncmethod = freqSyncMethodToString(rro.freqsyncMethod);
@@ -763,7 +766,7 @@ bool WebRadioInterface::send_mux_json(Socket& s)
                 service.errorcounters_frameerrors = errorcounters.num_frameErrors;
                 service.errorcounters_rserrors = errorcounters.num_rsErrors;
                 service.errorcounters_aacerrors = errorcounters.num_aacErrors;
-                service.errorcounters_time = chrono::system_clock::to_time_t(dls.time);
+                service.errorcounters_time = chrono::system_clock::to_time_t(errorcounters.time);
 
                 auto xpad_err = wph.getXPADErrors();
                 service.xpaderror_haserror = xpad_err.has_error;
@@ -932,12 +935,12 @@ bool WebRadioInterface::send_stream(Socket& s, const string& stream)
 
                 ProgrammeSender sender(move(s));
 
-                cerr << "Registering mp3 sender" << endl;
+                cerr << "Registering mp3 sender for " << to_hex(srv.serviceId, 4) << endl;
                 ph.registerSender(&sender);
                 check_decoders_required();
                 sender.wait_for_termination();
 
-                cerr << "Removing mp3 sender" << endl;
+                cerr << "Removing mp3 sender for " << to_hex(srv.serviceId, 4) << endl;
                 ph.removeSender(&sender);
                 check_decoders_required();
 
@@ -1299,8 +1302,6 @@ bool WebRadioInterface::handle_channel_post(Socket& s, const string& channel)
 void WebRadioInterface::handle_phs()
 {
     while (running) {
-        this_thread::sleep_for(chrono::seconds(2));
-
         unique_lock<mutex> lock(rx_mut);
         ASSERT_RX;
 
@@ -1406,6 +1407,8 @@ void WebRadioInterface::handle_phs()
                     }), carousel_services_active.end());
         lock.unlock();
         check_decoders_required();
+
+        this_thread::sleep_for(chrono::seconds(2));
     }
 
     cerr << "TEARDOWN Cancel all PHs and remove services" << endl;
@@ -1453,6 +1456,13 @@ void WebRadioInterface::serve()
 
     while (sig_caught == 0) {
         auto client = serverSocket.accept();
+
+        if (!client.valid()) {
+            if (sig_caught != 0) {
+                break;
+            }
+            continue;
+        }
 
         running_connections.push_back(async(launch::async,
                     &WebRadioInterface::dispatch_client, this, move(client)));

--- a/src/welle-cli/welle-cli.cpp
+++ b/src/welle-cli/welle-cli.cpp
@@ -54,6 +54,7 @@
 #include "backend/radio-receiver.h"
 #include "input/input_factory.h"
 #include "input/raw_file.h"
+#include "input/eti_file.h"
 #include "various/channels.h"
 #include "libs/json.hpp"
 extern "C" {
@@ -287,6 +288,8 @@ struct options_t {
     int gain = -1;
     string channel = "10B";
     string iqsource = "";
+// AI: ETI input file/pipe path (set by -E option).
+    string etisource = "";
     string programme = "GRRIF";
     string frontend = "auto";
     string frontend_args = "";
@@ -339,6 +342,7 @@ static void usage()
     "Backend and input options:" << endl <<
     "    -f file       Read an IQ file <file> and play with ALSA." << endl <<
     "                  IQ file format is u8, unless the file ends with 'FORMAT.iq'." << endl <<
+    "    -E file       Read an ETI-NI file <file> and decode services from ETI stream payload." << endl <<
     "    -u            Disable coarse corrector, for receivers who have a low " << endl <<
     "                  frequency offset." << endl <<
     "    -g gain       Set input gain to <gain> or -1 for auto gain." << endl <<
@@ -422,7 +426,7 @@ options_t parse_cmdline(int argc, char **argv)
     options.rro.decodeTII = true;
 
     int opt;
-    while ((opt = getopt(argc, argv, "A:c:C:dDf:F:g:hp:O:o:Ps:Tt:uvw:")) != -1) {
+    while ((opt = getopt(argc, argv, "A:c:C:dDE:f:F:g:hp:O:o:Ps:Tt:uvw:")) != -1) {
         switch (opt) {
             case 'A':
                 options.antenna = optarg;
@@ -441,6 +445,9 @@ options_t parse_cmdline(int argc, char **argv)
                 break;
             case 'f':
                 options.iqsource = optarg;
+                break;
+            case 'E':
+                options.etisource = optarg;
                 break;
             case 'F':
                 fe_opt = optarg;
@@ -503,6 +510,11 @@ options_t parse_cmdline(int argc, char **argv)
         exit(1);
     }
 
+    if (!options.iqsource.empty() && !options.etisource.empty()) {
+        cerr << "Cannot select both -f (IQ input) and -E (ETI input)" << endl;
+        exit(1);
+    }
+
     return options;
 }
 
@@ -530,7 +542,16 @@ int main(int argc, char **argv)
 
     unique_ptr<CVirtualInput> in = nullptr;
 
-    if (options.iqsource.empty()) {
+    if (!options.etisource.empty()) {
+        auto in_eti = make_unique<CETIFile>(ri);
+        in_eti->setFileName(options.etisource);
+        if (!in_eti->is_ok()) {
+            cerr << "Could not prepare CETIFile" << endl;
+            return 1;
+        }
+        in = move(in_eti);
+    }
+    else if (options.iqsource.empty()) {
         in.reset(CInputFactory::GetDevice(ri, options.frontend));
 
         if (not in) {
@@ -552,12 +573,14 @@ int main(int argc, char **argv)
         in = move(in_file);
     }
 
-    if (options.gain == -1) {
-        in->setAgc(true);
-    }
-    else {
-        in->setAgc(false);
-        in->setGain(options.gain);
+    if (!in->isEtiInput()) {
+        if (options.gain == -1) {
+            in->setAgc(true);
+        }
+        else {
+            in->setAgc(false);
+            in->setGain(options.gain);
+        }
     }
 
 
@@ -570,7 +593,7 @@ int main(int argc, char **argv)
         dynamic_cast<CSoapySdr*>(in.get())->setDeviceParam(DeviceParam::SoapySDRDriverArgs, options.soapySDRDriverArgs);
     }
 #endif
-    if (options.frontend == "rtl_tcp" && !options.frontend_args.empty()) {
+    if (!in->isEtiInput() && options.frontend == "rtl_tcp" && !options.frontend_args.empty()) {
         string args = options.frontend_args;
         size_t colon = args.find(':');
         if (colon == string::npos) {
@@ -589,8 +612,10 @@ int main(int argc, char **argv)
             // cout << "setting rtl_tcp host to '" << host << "', port to '" << atoi(port.c_str()) << "'" << endl;
         }
     }
-    auto freq = channels.getFrequency(options.channel);
-    in->setFrequency(freq);
+    if (!in->isEtiInput()) {
+        auto freq = channels.getFrequency(options.channel);
+        in->setFrequency(freq);
+    }
     string service_to_tune = options.programme;
     unsigned service_to_tune_idx = parse_service_to_tune(service_to_tune);
 


### PR DESCRIPTION
# What does this PR do and why is it necessary?

In my environment, welle-cli never had 0 errors. And, I was not lucky, that for ETI sources (like satellite feeds), we had first to use `odr-dabmod` and then connected welle-cli to this raw file (or pipe)

## Add ETI-NI input mode to welle-cli (-E option)

New input backend (CETIFile) reads raw or streamed ETI-NI frames from
a file, pipe, or stdin ("-").  Format detection scans forward up to one
full frame to find the sync word, handling non-seekable sources via a
peek-replay buffer.

New ETIProcessor decouples pipe I/O (reader thread) from audio decoding
(processor thread) via a bounded frame queue so heavy AAC/RS processing
never creates back-pressure on the upstream eti-cmdline/dab2eti process.

ETI frame parser extracts FIC (fed to FicHandler::processFibBytes) and
per-subchannel MSC payloads (routed through MscHandler::processEtiStream
→ DecoderAdapter::feedRawFrame → SuperframeFilter), bypassing the OFDM
and Viterbi stages entirely.

Web UI and mux.json changes:
- inputmode field (rf / eti) in mux.json
- ETI mode hides channel selector, spectrum, CIR, constellation, TII,
  SNR, gain and advanced RF controls
- Scheduler no longer tears down DecoderAdapters on transient FIC CRC
  misses (prevents periodic audible dropouts in live ETI mode)

Diagnostics and polish:
- FECInfo moved after CheckSync so pre-sync RS errors don't inflate the
  web UI error counters
- Console logging added for frame / RS / AAC decode errors
- Service IDs printed in hex in audio stream log messages
- Shutdown EINTR / invalid-socket log noise removed
- Audio level computed from absolute peak value
- All AI-inserted code sections marked with // AI: comments

# How was it tested? How can it be tested by the reviewer?
tested on my laptop (Ubuntu 64bit 25.10) with live signals from rtlsdr (via dab2eti or eti-cmdline-rtlsdr) or from satellite for example for 1st German Bundesmux via Astra 19E.

`curl  http://sf8008.local:8001/1:0:2:1019:5:85:C00000:0:0:0:  | fedi2eti 4121 239.128.43.43 50043 | welle-cli -E - -Dw 8888 2>&1 | ts`

# Any background context you want to provide?

Hint: Code made thanks to AI, i just tested to outcome.

## webfrontend layout and content changes

    - Reworked service table layout and column sizing for better readability.
    - Moved audio meters below Play, added L/R labels, improved colors, tightened spacing.
    - Hid Play/audio controls for data services.
    - Improved technical-details formatting to concise codec/mode/rate output.
    - Normalized HE-AACv2 display to Parametric Stereo format.
    - Fixed phantom horizontal scroll and cropping issues.
    - Separated service-table scrolling from other tables for reliable responsive behavior.
    - Enhanced mobile card view (first column as card header).
    - Updated SLS thumbnail handling to fixed height with variable aspect ratio.
    - Added Free CUs summary row and made it visible in responsive mode.

# Screenshots (if appropriate)
<img width="1920" height="1080" alt="grafik" src="https://github.com/user-attachments/assets/ebfb9bdd-80ff-4ea7-896c-7c68c0c70408" />

#### Further notes
welle-io not tested!