### PR TITLE
Update rtl-sdr

### DIFF
--- a/io.welle.welle-gui.yml
+++ b/io.welle.welle-gui.yml
@@ -35,7 +35,7 @@ modules:
     sources:
       - type: git
         url: 'https://gitea.osmocom.org/sdr/rtl-sdr.git'
-        tag: v2.0.2
+        tag: v2.0.3
 
   - name: libairspy
     buildsystem: cmake-ninja


### PR DESCRIPTION
Latest 2.0.3 release for RTL-SDR Blog V4L support and other improvements.

Flathub PR: https://github.com/flathub/io.welle.welle-gui/pull/9