### PR TITLE
feat(macos): restore builds and CI packaging

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -73,7 +73,11 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: brew install cmake ninja fftw faad2 mpg123 lame librtlsdr dylibbundler
+        run: |
+          if brew tap | grep -qx 'aws/tap'; then
+            brew untap aws/tap
+          fi
+          brew install cmake ninja fftw faad2 mpg123 lame librtlsdr dylibbundler
 
       - name: Configure
         run: >-

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,12 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - macos: '14'
-            architecture: arm64
-            runner: macos-14
-          - macos: '14'
-            architecture: x86_64
-            runner: macos-14-large
           - macos: '15'
             architecture: arm64
             runner: macos-15

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: brew install cmake ninja fftw faad2 mpg123 lame librtlsdr
+        run: brew install cmake ninja fftw faad2 mpg123 lame librtlsdr dylibbundler
 
       - name: Configure
         run: >-
@@ -61,17 +61,25 @@ jobs:
           macdeployqt build/welle-io.app \
             -qmldir=src/welle-gui/QML \
             -libpath="$QT_ROOT/lib" \
-            -libpath="$(brew --prefix)/lib" \
-            -no-codesign
+            -libpath="$(brew --prefix)/lib"
+          dylibbundler -b \
+            -x build/welle-io.app/Contents/MacOS/welle-io \
+            -d build/welle-io.app/Contents/Frameworks \
+            -p @executable_path/../Frameworks \
+            -cd -of -ns
           codesign --force --deep --sign - build/welle-io.app
           codesign --verify --deep --strict build/welle-io.app
+          if otool -L build/welle-io.app/Contents/MacOS/welle-io | grep -Eq '/(opt/homebrew|usr/local)/'; then
+            echo "Application still links to Homebrew libraries" >&2
+            exit 1
+          fi
           build/welle-io.app/Contents/MacOS/welle-io --version
 
       - name: Archive application bundle
         run: ditto -c -k --sequesterRsrc --keepParent build/welle-io.app "welle-io-${{ matrix.runner }}.zip"
 
       - name: Upload application bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: welle.io-${{ matrix.runner }}
           path: welle-io-${{ matrix.runner }}.zip

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,9 +12,6 @@ jobs:
   build:
     name: Build on macOS ${{ matrix.macos }} (${{ matrix.architecture }})
     runs-on: ${{ matrix.runner }}
-    env:
-      SFTP_USER: ${{ secrets.SFTP_USER }}
-      SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,29 +37,8 @@ jobs:
 
       - name: Set package metadata
         run: |
-          case "$(uname -m)" in
-            arm64)
-              arch=arm64
-              ;;
-            x86_64)
-              arch=x86_64
-              ;;
-            *)
-              echo "Unsupported architecture: $(uname -m)" >&2
-              exit 1
-              ;;
-          esac
-
-          if [ "$arch" != "${{ matrix.architecture }}" ]; then
-            echo "Runner architecture $arch does not match expected architecture ${{ matrix.architecture }}" >&2
-            exit 1
-          fi
-
-          {
-            echo "DATE=$(date +%Y%m%d)"
-            echo "GIT_HASH=$(git rev-parse --short HEAD)"
-            echo "ARCH_SUFFIX=$arch"
-          } >> "$GITHUB_ENV"
+          echo "DATE=$(date +%Y%m%d)" >> "$GITHUB_ENV"
+          echo "GIT_HASH=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -72,17 +48,17 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: |
-          if brew tap | grep -qx 'aws/tap'; then
-            brew untap aws/tap
-          fi
-          brew install cmake ninja fftw faad2 mpg123 lame librtlsdr dylibbundler
+        env:
+          # Skip brew's automatic update, which fails on stale third-party
+          # taps preinstalled on the runner images (e.g. aws/tap).
+          HOMEBREW_NO_AUTO_UPDATE: '1'
+        run: brew install ninja fftw faad2 mpg123 lame librtlsdr dylibbundler
 
       - name: Configure
         run: >-
           cmake -S . -B build -G Ninja
           -DCMAKE_BUILD_TYPE=Release
-          -DCMAKE_PREFIX_PATH="$QT_ROOT"
+          -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR"
           -DRTLSDR=ON
 
       - name: Build
@@ -99,41 +75,33 @@ jobs:
 
       - name: Deploy application bundle
         run: |
-          macdeployqt build/welle-io.app \
-            -qmldir=src/welle-gui/QML \
-            -libpath="$QT_ROOT/lib" \
-            -libpath="$(brew --prefix)/lib"
-          dylibbundler -b \
-            -x build/welle-io.app/Contents/MacOS/welle-io \
-            -d build/welle-io.app/Contents/Frameworks \
-            -p @executable_path/../Frameworks \
-            -cd -of -ns
-          codesign --force --deep --sign - build/welle-io.app
-          codesign --verify --deep --strict build/welle-io.app
-          if otool -L build/welle-io.app/Contents/MacOS/welle-io | grep -Eq '/(opt/homebrew|usr/local)/'; then
-            echo "Application still links to Homebrew libraries" >&2
-            exit 1
-          fi
+          scripts/macos-deploy.sh "$QT_ROOT_DIR"
           build/welle-io.app/Contents/MacOS/welle-io --version
 
       - name: Create distribution package
         run: |
           mkdir publish
-          package_name="${DATE}_${GIT_HASH}_macOS_welle-io_${{ matrix.runner }}_${ARCH_SUFFIX}.zip"
+          package_name="${DATE}_${GIT_HASH}_macOS${{ matrix.macos }}_welle-io_${{ matrix.architecture }}.zip"
           ditto -c -k --sequesterRsrc --keepParent build/welle-io.app "publish/$package_name"
           unzip -tq "publish/$package_name"
 
       - name: Archive artifacts (welle.io macOS application)
         uses: actions/upload-artifact@v7
         with:
-          name: welle.io macOS ${{ matrix.macos }} application (${{ env.ARCH_SUFFIX }})
+          name: welle.io macOS ${{ matrix.macos }} application (${{ matrix.architecture }})
           path: publish/*
           if-no-files-found: error
+          compression-level: 0
 
       - name: Upload to nightly server
+        # The push trigger already restricts refs to master and next*. The
+        # env indirection exists because the secrets context is not allowed
+        # in a step-level if.
+        env:
+          SFTP_USER: ${{ secrets.SFTP_USER }}
+          SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
         if: >-
           github.event_name == 'push' &&
-          (github.ref_name == 'master' || startsWith(github.ref_name, 'next')) &&
           env.SFTP_USER != '' &&
           env.SFTP_PASSWORD != ''
         uses: dennisameling/ftp-upload-action@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - next
+      - 'next*'
       - fix/macos-build
   pull_request:
   workflow_dispatch:
@@ -13,6 +13,9 @@ jobs:
   build:
     name: Build on ${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
+    env:
+      SFTP_USER: ${{ secrets.SFTP_USER }}
+      SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +29,27 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Set package metadata
+        run: |
+          case "$(uname -m)" in
+            arm64)
+              arch=arm64
+              ;;
+            x86_64)
+              arch=x86_64
+              ;;
+            *)
+              echo "Unsupported architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "DATE=$(date +%Y%m%d)"
+            echo "GIT_HASH=$(git rev-parse --short HEAD)"
+            echo "ARCH_SUFFIX=$arch"
+          } >> "$GITHUB_ENV"
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v4
@@ -75,12 +99,30 @@ jobs:
           fi
           build/welle-io.app/Contents/MacOS/welle-io --version
 
-      - name: Archive application bundle
-        run: ditto -c -k --sequesterRsrc --keepParent build/welle-io.app "welle-io-${{ matrix.runner }}.zip"
+      - name: Create distribution package
+        run: |
+          mkdir publish
+          package_name="${DATE}_${GIT_HASH}_macOS_welle-io_${{ matrix.runner }}_${ARCH_SUFFIX}.zip"
+          ditto -c -k --sequesterRsrc --keepParent build/welle-io.app "publish/$package_name"
+          unzip -tq "publish/$package_name"
 
-      - name: Upload application bundle
+      - name: Archive artifacts (welle.io macOS application)
         uses: actions/upload-artifact@v7
         with:
-          name: welle.io-${{ matrix.runner }}
-          path: welle-io-${{ matrix.runner }}.zip
+          name: welle.io macOS application (${{ matrix.runner }}, ${{ env.ARCH_SUFFIX }})
+          path: publish/*
           if-no-files-found: error
+
+      - name: Upload to nightly server
+        if: >-
+          github.event_name == 'push' &&
+          (github.ref_name == 'master' || startsWith(github.ref_name, 'next')) &&
+          env.SFTP_USER != '' &&
+          env.SFTP_PASSWORD != ''
+        uses: dennisameling/ftp-upload-action@v2
+        with:
+          server: a2f24.netcup.net
+          secure: true
+          username: ${{ env.SFTP_USER }}
+          password: ${{ env.SFTP_PASSWORD }}
+          local_dir: publish/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - 'next*'
-      - fix/macos-build
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,78 @@
+name: macOS build
+
+on:
+  push:
+    branches:
+      - master
+      - next
+      - fix/macos-build
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build on ${{ matrix.runner }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-14
+          - macos-15
+          - macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4
+        with:
+          version: '6.10.1'
+          modules: 'qtcharts qtmultimedia qt5compat qtshadertools'
+          cache: true
+
+      - name: Install dependencies
+        run: brew install cmake ninja fftw faad2 mpg123 lame librtlsdr
+
+      - name: Configure
+        run: >-
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH="$QT_ROOT"
+          -DRTLSDR=ON
+
+      - name: Build
+        run: cmake --build build --parallel
+
+      - name: Smoke test
+        run: |
+          test -x build/welle-io.app/Contents/MacOS/welle-io
+          test -x build/welle-cli
+          plutil -lint build/welle-io.app/Contents/Info.plist
+          test "$(plutil -extract CFBundleIdentifier raw build/welle-io.app/Contents/Info.plist)" = "io.welle.welle"
+          build/welle-io.app/Contents/MacOS/welle-io --version
+          build/welle-cli -h 2>&1 | grep -q "Usage: welle-cli"
+
+      - name: Deploy application bundle
+        run: |
+          macdeployqt build/welle-io.app \
+            -qmldir=src/welle-gui/QML \
+            -libpath="$QT_ROOT/lib" \
+            -libpath="$(brew --prefix)/lib" \
+            -no-codesign
+          codesign --force --deep --sign - build/welle-io.app
+          codesign --verify --deep --strict build/welle-io.app
+          build/welle-io.app/Contents/MacOS/welle-io --version
+
+      - name: Archive application bundle
+        run: ditto -c -k --sequesterRsrc --keepParent build/welle-io.app "welle-io-${{ matrix.runner }}.zip"
+
+      - name: Upload application bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: welle.io-${{ matrix.runner }}
+          path: welle-io-${{ matrix.runner }}.zip
+          if-no-files-found: error

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: Build on ${{ matrix.runner }}
+    name: Build on macOS ${{ matrix.macos }} (${{ matrix.architecture }})
     runs-on: ${{ matrix.runner }}
     env:
       SFTP_USER: ${{ secrets.SFTP_USER }}
@@ -19,10 +19,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - macos-14
-          - macos-15
-          - macos-26
+        include:
+          - macos: '14'
+            architecture: arm64
+            runner: macos-14
+          - macos: '14'
+            architecture: x86_64
+            runner: macos-14-large
+          - macos: '15'
+            architecture: arm64
+            runner: macos-15
+          - macos: '15'
+            architecture: x86_64
+            runner: macos-15-intel
+          - macos: '26'
+            architecture: arm64
+            runner: macos-26
+          - macos: '26'
+            architecture: x86_64
+            runner: macos-26-intel
 
     steps:
       - name: Checkout
@@ -44,6 +59,11 @@ jobs:
               exit 1
               ;;
           esac
+
+          if [ "$arch" != "${{ matrix.architecture }}" ]; then
+            echo "Runner architecture $arch does not match expected architecture ${{ matrix.architecture }}" >&2
+            exit 1
+          fi
 
           {
             echo "DATE=$(date +%Y%m%d)"
@@ -109,7 +129,7 @@ jobs:
       - name: Archive artifacts (welle.io macOS application)
         uses: actions/upload-artifact@v7
         with:
-          name: welle.io macOS application (${{ matrix.runner }}, ${{ env.ARCH_SUFFIX }})
+          name: welle.io macOS ${{ matrix.macos }} application (${{ env.ARCH_SUFFIX }})
           path: publish/*
           if-no-files-found: error
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea/
 /cmake-build-debug/
 build/
+build-*/
 builddir/
 .flatpak-builder/
 repo/

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ codesign --force --deep --sign - build/welle-io.app
 codesign --verify --deep --strict build/welle-io.app
 ```
 
+GitHub Actions performs this build on every supported macOS runner. Each deployed application bundle is archived as
+`YYYYMMDD_GITHASH_macOS_welle-io_RUNNER_ARCH.zip` and retained as a workflow artifact. Pushes to `master`, `next`, or
+a branch starting with `next` also upload the package to the nightly server when its credentials are configured. As
+with the Windows and Linux packages, adding a stable package to a GitHub Release remains a manual release step.
+
 #### Android and FreeBSD
 
 These operating systems are not maintained currently. You can find the original compiling instructions in the old [README.md](https://github.com/AlbrechtL/welle.io/blob/fdcd3c588a6e592b9640aad71648dcf6228fa98f/README.md).

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This section shows how to compile welle.io on Windows 11. Windows 10 and 7  shou
 The CMake build is tested on the macOS 14, 15 and 26 GitHub-hosted runners. Install the build dependencies with [Homebrew](https://brew.sh/):
 
 ```
-brew install cmake ninja qt fftw faad2 mpg123 lame librtlsdr
+brew install cmake ninja qt fftw faad2 mpg123 lame librtlsdr dylibbundler
 ```
 
 Configure and build the application bundle and command-line tool:
@@ -202,8 +202,12 @@ The resulting application is `build/welle-io.app`. To make a self-contained bund
 "$(brew --prefix qt)/bin/macdeployqt" build/welle-io.app \
   -qmldir=src/welle-gui/QML \
   -libpath="$(brew --prefix qt)/lib" \
-  -libpath="$(brew --prefix)/lib" \
-  -no-codesign
+  -libpath="$(brew --prefix)/lib"
+dylibbundler -b \
+  -x build/welle-io.app/Contents/MacOS/welle-io \
+  -d build/welle-io.app/Contents/Frameworks \
+  -p @executable_path/../Frameworks \
+  -cd -of -ns
 codesign --force --deep --sign - build/welle-io.app
 codesign --verify --deep --strict build/welle-io.app
 ```

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ This section shows how to compile welle.io on Windows 11. Windows 10 and 7  shou
 
 #### macOS
 
-The CMake build is tested on the macOS 14, 15 and 26 GitHub-hosted runners. Install the build dependencies with [Homebrew](https://brew.sh/):
+The CMake build is tested on the macOS 14, 15 and 26 GitHub-hosted runners for both Apple Silicon (ARM64) and Intel
+(AMD64/x86_64). Install the build dependencies with [Homebrew](https://brew.sh/):
 
 ```
 brew install cmake ninja qt fftw faad2 mpg123 lame librtlsdr dylibbundler

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please see the project website https://www.welle.io for a user oriented document
 
 **Build status**
 - Linux (Flatpak x86_64 and arm64): [![Linux build](https://github.com/AlbrechtL/welle.io/actions/workflows/linux.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/linux.yml)
-- macOS 14, 15 and 26: [![macOS build](https://github.com/rmens/welle.io/actions/workflows/macos.yml/badge.svg)](https://github.com/rmens/welle.io/actions/workflows/macos.yml)
+- macOS 15 and 26: [![macOS build](https://github.com/rmens/welle.io/actions/workflows/macos.yml/badge.svg)](https://github.com/rmens/welle.io/actions/workflows/macos.yml)
 - Windows (Installer x86_64): [![Windows build](https://github.com/AlbrechtL/welle.io/actions/workflows/windows.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/windows.yml)
 - Android (APK): build workflow is currently disabled because a new, skilled maintainer for Android package is required to fix bug https://github.com/AlbrechtL/welle.io/issues/814# in the workflow.
 
@@ -180,7 +180,7 @@ This section shows how to compile welle.io on Windows 11. Windows 10 and 7  shou
 
 #### macOS
 
-The CMake build is tested on the macOS 14, 15 and 26 GitHub-hosted runners for both Apple Silicon (ARM64) and Intel
+The CMake build is tested on the macOS 15 and 26 GitHub-hosted runners for both Apple Silicon (ARM64) and Intel
 (AMD64/x86_64). Install the build dependencies with [Homebrew](https://brew.sh/):
 
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please see the project website https://www.welle.io for a user oriented document
 
 **Build status**
 - Linux (Flatpak x86_64 and arm64): [![Linux build](https://github.com/AlbrechtL/welle.io/actions/workflows/linux.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/linux.yml)
-- macOS 15 and 26: [![macOS build](https://github.com/rmens/welle.io/actions/workflows/macos.yml/badge.svg)](https://github.com/rmens/welle.io/actions/workflows/macos.yml)
+- macOS 15 and 26: [![macOS build](https://github.com/AlbrechtL/welle.io/actions/workflows/macos.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/macos.yml)
 - Windows (Installer x86_64): [![Windows build](https://github.com/AlbrechtL/welle.io/actions/workflows/windows.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/windows.yml)
 - Android (APK): build workflow is currently disabled because a new, skilled maintainer for Android package is required to fix bug https://github.com/AlbrechtL/welle.io/issues/814# in the workflow.
 
@@ -19,7 +19,8 @@ Please see the project website https://www.welle.io for a user oriented document
     * [General Information](#general-information)
     * [Debian / Ubuntu Linux](#debian--ubuntu-linux)
     * [Windows 11](#windows-11)
-    * [macOS, Android and FreeBSD](#macos-android-and-freebsd)
+    * [macOS](#macos)
+    * [Android and FreeBSD](#android-and-freebsd)
     * [CMake](#cmake)
   * [welle-cli](#welle-cli)
     * [Usage](#usage-of-welle-cli)
@@ -69,7 +70,7 @@ If you discovered an issue please open a new [issue](https://github.com/Albrecht
 #### Developer version
 
 welle.io is under development. You can also try the latest developer builds. But PLEASE BE WARNED the builds are automatically created and untested.
-* [welle.io nightly builds](https://welle-io-nightlies.albrechtloh.de/) (Windows, Linux)
+* [welle.io nightly builds](https://welle-io-nightlies.albrechtloh.de/) (Windows, Linux, macOS)
 * Build artifacts in [Actions](https://github.com/AlbrechtL/welle.io/actions) runs
 
 
@@ -216,7 +217,8 @@ codesign --verify --deep --strict build/welle-io.app
 GitHub Actions performs this build on every supported macOS runner. Each deployed application bundle is archived as
 `YYYYMMDD_GITHASH_macOS_welle-io_RUNNER_ARCH.zip` and retained as a workflow artifact. Pushes to `master`, `next`, or
 a branch starting with `next` also upload the package to the nightly server when its credentials are configured. As
-with the Windows and Linux packages, adding a stable package to a GitHub Release remains a manual release step.
+these CI packages use an ad-hoc signature, macOS may require the user to approve them in Privacy & Security before
+opening. A stable release still requires Developer ID signing and Apple notarization and remains a manual release step.
 
 #### Android and FreeBSD
 

--- a/README.md
+++ b/README.md
@@ -201,22 +201,12 @@ cmake --build build --parallel
 The resulting application is `build/welle-io.app`. To make a self-contained bundle for another Mac, deploy its Qt and Homebrew libraries and apply an ad-hoc signature:
 
 ```
-"$(brew --prefix qt)/bin/macdeployqt" build/welle-io.app \
-  -qmldir=src/welle-gui/QML \
-  -libpath="$(brew --prefix qt)/lib" \
-  -libpath="$(brew --prefix)/lib"
-dylibbundler -b \
-  -x build/welle-io.app/Contents/MacOS/welle-io \
-  -d build/welle-io.app/Contents/Frameworks \
-  -p @executable_path/../Frameworks \
-  -cd -of -ns
-codesign --force --deep --sign - build/welle-io.app
-codesign --verify --deep --strict build/welle-io.app
+scripts/macos-deploy.sh "$(brew --prefix qt)"
 ```
 
 GitHub Actions performs this build on every supported macOS runner. Each deployed application bundle is archived as
-`YYYYMMDD_GITHASH_macOS_welle-io_RUNNER_ARCH.zip` and retained as a workflow artifact. Pushes to `master`, `next`, or
-a branch starting with `next` also upload the package to the nightly server when its credentials are configured. As
+`YYYYMMDD_GITHASH_macOSVERSION_welle-io_ARCH.zip` and retained as a workflow artifact. Pushes to `master` or branches
+starting with `next` also upload the package to the nightly server when its credentials are configured. As
 these CI packages use an ad-hoc signature, macOS may require the user to approve them in Privacy & Security before
 opening. A stable release still requires Developer ID signing and Apple notarization and remains a manual release step.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Please see the project website https://www.welle.io for a user oriented document
 
 **Build status**
 - Linux (Flatpak x86_64 and arm64): [![Linux build](https://github.com/AlbrechtL/welle.io/actions/workflows/linux.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/linux.yml)
+- macOS 14, 15 and 26: [![macOS build](https://github.com/rmens/welle.io/actions/workflows/macos.yml/badge.svg)](https://github.com/rmens/welle.io/actions/workflows/macos.yml)
 - Windows (Installer x86_64): [![Windows build](https://github.com/AlbrechtL/welle.io/actions/workflows/windows.yml/badge.svg)](https://github.com/AlbrechtL/welle.io/actions/workflows/windows.yml)
 - Android (APK): build workflow is currently disabled because a new, skilled maintainer for Android package is required to fix bug https://github.com/AlbrechtL/welle.io/issues/814# in the workflow.
 
@@ -51,8 +52,8 @@ Please see the project website https://www.welle.io for a user oriented document
     $ sudo dnf install --refresh welle-io
     ```
 * **macOS**
-  Unfortunately the macOS welle.io is unmaintained, currently. You still can use the 2.4 version (only Intel processor support).
-  - [Installer](https://github.com/AlbrechtL/welle.io/releases/tag/v2.4)
+  The current source tree builds on both Apple Silicon and Intel Macs. See the [macOS build instructions](#macos) below.
+  - [Legacy 2.4 Intel installer](https://github.com/AlbrechtL/welle.io/releases/tag/v2.4)
   - MacPorts
     ```
     $ sudo port install welle.io
@@ -177,9 +178,39 @@ This section shows how to compile welle.io on Windows 11. Windows 10 and 7  shou
 5. Build welle.io
 6. Run welle.io and enjoy it
 
-#### macOS, Android and FreeBSD
+#### macOS
 
-These operating systems are not maintain, currently. You can find the original compiling insturections in the old [README.md](https://github.com/AlbrechtL/welle.io/blob/fdcd3c588a6e592b9640aad71648dcf6228fa98f/README.md).
+The CMake build is tested on the macOS 14, 15 and 26 GitHub-hosted runners. Install the build dependencies with [Homebrew](https://brew.sh/):
+
+```
+brew install cmake ninja qt fftw faad2 mpg123 lame librtlsdr
+```
+
+Configure and build the application bundle and command-line tool:
+
+```
+cmake -S . -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$(brew --prefix qt)" \
+  -DRTLSDR=ON
+cmake --build build --parallel
+```
+
+The resulting application is `build/welle-io.app`. To make a self-contained bundle for another Mac, deploy its Qt and Homebrew libraries and apply an ad-hoc signature:
+
+```
+"$(brew --prefix qt)/bin/macdeployqt" build/welle-io.app \
+  -qmldir=src/welle-gui/QML \
+  -libpath="$(brew --prefix qt)/lib" \
+  -libpath="$(brew --prefix)/lib" \
+  -no-codesign
+codesign --force --deep --sign - build/welle-io.app
+codesign --verify --deep --strict build/welle-io.app
+```
+
+#### Android and FreeBSD
+
+These operating systems are not maintained currently. You can find the original compiling instructions in the old [README.md](https://github.com/AlbrechtL/welle.io/blob/fdcd3c588a6e592b9640aad71648dcf6228fa98f/README.md).
 
 
 #### CMake

--- a/scripts/macos-deploy.sh
+++ b/scripts/macos-deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Make build/welle-io.app self-contained: deploy its Qt and Homebrew
+# libraries into the bundle and apply an ad-hoc signature.
+# Used by .github/workflows/macos.yml and the README macOS instructions.
+#
+# Usage: scripts/macos-deploy.sh <qt-prefix> [app-bundle]
+#   qt-prefix   Qt installation prefix, e.g. "$(brew --prefix qt)"
+#   app-bundle  path to the app bundle (default: build/welle-io.app)
+set -eu
+
+qt_prefix=${1:?usage: $0 <qt-prefix> [app-bundle]}
+app=${2:-build/welle-io.app}
+
+"$qt_prefix/bin/macdeployqt" "$app" \
+    -qmldir=src/welle-gui/QML \
+    -libpath="$qt_prefix/lib" \
+    -libpath="$(brew --prefix)/lib"
+dylibbundler -b \
+    -x "$app/Contents/MacOS/welle-io" \
+    -d "$app/Contents/Frameworks" \
+    -p @executable_path/../Frameworks \
+    -cd -of -ns
+codesign --force --deep --sign - "$app"
+codesign --verify --deep --strict "$app"
+if otool -L "$app/Contents/MacOS/welle-io" | grep -Eq '/(opt/homebrew|usr/local)/'; then
+    echo "Application still links to Homebrew libraries" >&2
+    exit 1
+fi

--- a/src/various/ringbuffer.h
+++ b/src/various/ringbuffer.h
@@ -82,59 +82,18 @@
  *  single reader and a single writer.
  *  Mostly used for getting samples from or to the soundcard
  */
-#if defined(__APPLE__)
-    /* Use the standard C++ memory barriers instead of Apple's deprecated
-       OSMemoryBarrier API. */
-#   define PaUtil_FullMemoryBarrier()  std::atomic_thread_fence(std::memory_order_seq_cst)
-#   define PaUtil_ReadMemoryBarrier()  std::atomic_thread_fence(std::memory_order_acquire)
-#   define PaUtil_WriteMemoryBarrier() std::atomic_thread_fence(std::memory_order_release)
-#elif defined(__GNUC__)
-    /* GCC >= 4.1 has built-in intrinsics. We'll use those */
-#   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
-# define PaUtil_FullMemoryBarrier()  __sync_synchronize()
-# define PaUtil_ReadMemoryBarrier()  __sync_synchronize()
-# define PaUtil_WriteMemoryBarrier() __sync_synchronize()
-    /* as a fallback, GCC understands volatile asm and "memory" to mean it
-     * should not reorder memory read/writes */
-#   elif defined( __PPC__ )
-#      define PaUtil_FullMemoryBarrier()  asm volatile("sync":::"memory")
-#      define PaUtil_ReadMemoryBarrier()  asm volatile("sync":::"memory")
-#      define PaUtil_WriteMemoryBarrier() asm volatile("sync":::"memory")
-#   elif defined( __i386__ ) || defined( __i486__ ) || defined( __i586__ ) || defined( __i686__ ) || defined( __x86_64__ )
-#      define PaUtil_FullMemoryBarrier()  asm volatile("mfence":::"memory")
-#      define PaUtil_ReadMemoryBarrier()  asm volatile("lfence":::"memory")
-#      define PaUtil_WriteMemoryBarrier() asm volatile("sfence":::"memory")
-#   else
-#      ifdef ALLOW_SMP_DANGERS
-#         warning Memory barriers not defined on this system or system unknown
-#         warning For SMP safety, you should fix this.
-#         define PaUtil_FullMemoryBarrier()
-#         define PaUtil_ReadMemoryBarrier()
-#         define PaUtil_WriteMemoryBarrier()
-#      else
-#         error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
-#      endif
-#   endif
-#else
-#   ifdef ALLOW_SMP_DANGERS
-#      warning Memory barriers not defined on this system or system unknown
-#      warning For SMP safety, you should fix this.
-#      define PaUtil_FullMemoryBarrier()
-#      define PaUtil_ReadMemoryBarrier()
-#      define PaUtil_WriteMemoryBarrier()
-#   else
-#      error Memory barriers are not defined on this system. You can still compile by defining ALLOW_SMP_DANGERS, but SMP safety will not be guaranteed.
-#   endif
-#endif
-
 // Base implementation
 template <class elementtype>
 class RingBuffer
 {
     private:
         uint32_t    bufferSize;
-        volatile    uint32_t    writeIndex;
-        volatile    uint32_t    readIndex;
+        /* All synchronization between the producer and the consumer thread
+           happens through these indices: the data writes/reads are ordered
+           by acquire loads and release stores of the index owned by the
+           other side. */
+        std::atomic<uint32_t>   writeIndex;
+        std::atomic<uint32_t>   readIndex;
         uint32_t    bigMask;
         uint32_t    smallMask;
         std::vector<char> buffer;
@@ -167,7 +126,8 @@ class RingBuffer
         }
 
         int32_t GetRingBufferReadAvailable (void) {
-            return (writeIndex - readIndex) & bigMask;
+            return (writeIndex.load(std::memory_order_acquire) -
+                    readIndex.load(std::memory_order_acquire)) & bigMask;
         }
 
         int32_t ReadSpace   (void){
@@ -183,24 +143,24 @@ class RingBuffer
         }
 
         void    FlushRingBuffer () {
-            writeIndex  = 0;
-            readIndex   = 0;
-        }
-        /* ensure that previous writes are seen before we update the write index
-           (write after write)
-           */
-        int32_t AdvanceRingBufferWriteIndex (int32_t elementCount) {
-            PaUtil_WriteMemoryBarrier();
-            return writeIndex = (writeIndex + elementCount) & bigMask;
+            writeIndex.store(0, std::memory_order_release);
+            readIndex.store(0, std::memory_order_release);
         }
 
-        /* ensure that previous reads (copies out of the ring buffer) are
-         * always completed before updating (writing) the read index.
-         * (write-after-read) => full barrier
-         */
+        /* Producer only: the release store publishes the data written into
+           the buffer before the new write index becomes visible. */
+        int32_t AdvanceRingBufferWriteIndex (int32_t elementCount) {
+            uint32_t index = (writeIndex.load(std::memory_order_relaxed) + elementCount) & bigMask;
+            writeIndex.store(index, std::memory_order_release);
+            return index;
+        }
+
+        /* Consumer only: the release store orders the copies out of the
+           buffer before the space is handed back to the producer. */
         int32_t AdvanceRingBufferReadIndex (int32_t elementCount) {
-            PaUtil_FullMemoryBarrier();
-            return readIndex = (readIndex + elementCount) & bigMask;
+            uint32_t index = (readIndex.load(std::memory_order_relaxed) + elementCount) & bigMask;
+            readIndex.store(index, std::memory_order_release);
+            return index;
         }
 
         /***************************************************************************
@@ -213,13 +173,16 @@ class RingBuffer
                 void **dataPtr1, int32_t *sizePtr1,
                 void **dataPtr2, int32_t *sizePtr2 ) {
             uint32_t   index;
+            /* The acquire load of readIndex (inside the call below) pairs
+               with the consumer's release store, so the space returned here
+               is safe to overwrite. */
             uint32_t   available = GetRingBufferWriteAvailable ();
 
             if (elementCount > available)
                 elementCount = available;
 
             /* Check to see if write is not contiguous. */
-            index = writeIndex & smallMask;
+            index = writeIndex.load(std::memory_order_relaxed) & smallMask;
             if ((index + elementCount) > bufferSize ) {
                 /* Write data in two blocks that wrap the buffer. */
                 int32_t   firstHalf = bufferSize - index;
@@ -235,9 +198,6 @@ class RingBuffer
                 *sizePtr2    = 0;
             }
 
-            if (available > 0)
-                PaUtil_FullMemoryBarrier(); /* (write-after-read) => full barrier */
-
             return elementCount;
         }
 
@@ -251,13 +211,16 @@ class RingBuffer
                 void **dataPtr1, int32_t *sizePtr1,
                 void **dataPtr2, int32_t *sizePtr2) {
             uint32_t   index;
-            uint32_t   available = GetRingBufferReadAvailable (); /* doesn't use memory barrier */
+            /* The acquire load of writeIndex (inside the call below) pairs
+               with the producer's release store, so the data returned here
+               is safe to read. */
+            uint32_t   available = GetRingBufferReadAvailable ();
 
             if (elementCount > available)
                 elementCount = available;
 
             /* Check to see if read is not contiguous. */
-            index = readIndex & smallMask;
+            index = readIndex.load(std::memory_order_relaxed) & smallMask;
             if ((index + elementCount) > bufferSize) {
                 /* Write data in two blocks that wrap the buffer. */
                 int32_t firstHalf = bufferSize - index;
@@ -272,9 +235,6 @@ class RingBuffer
                 *dataPtr2 = NULL;
                 *sizePtr2 = 0;
             }
-
-            if (available)
-                PaUtil_ReadMemoryBarrier(); /* (read-after-read) => read barrier */
 
             return elementCount;
         }
@@ -325,8 +285,6 @@ class RingBuffer
         }
 
         int32_t skipDataInBuffer (int32_t n_values) {
-            //  ensure that we have the correct read and write indices
-            PaUtil_FullMemoryBarrier ();
             if (n_values > GetRingBufferReadAvailable ())
                 n_values = GetRingBufferReadAvailable ();
             AdvanceRingBufferReadIndex (n_values);

--- a/src/various/ringbuffer.h
+++ b/src/various/ringbuffer.h
@@ -70,6 +70,7 @@
 #define RING_BUFFER_H
 
 #include    <stdlib.h>
+#include    <atomic>
 #include    <vector>
 #include    <stdio.h>
 #include    <string.h>
@@ -82,13 +83,11 @@
  *  Mostly used for getting samples from or to the soundcard
  */
 #if defined(__APPLE__)
-#   include <libkern/OSAtomic.h>
-    /* Here are the memory barrier functions. Mac OS X only provides
-       full memory barriers, so the three types of barriers are the same,
-       however, these barriers are superior to compiler-based ones. */
-#   define PaUtil_FullMemoryBarrier()  OSMemoryBarrier()
-#   define PaUtil_ReadMemoryBarrier()  OSMemoryBarrier()
-#   define PaUtil_WriteMemoryBarrier() OSMemoryBarrier()
+    /* Use the standard C++ memory barriers instead of Apple's deprecated
+       OSMemoryBarrier API. */
+#   define PaUtil_FullMemoryBarrier()  std::atomic_thread_fence(std::memory_order_seq_cst)
+#   define PaUtil_ReadMemoryBarrier()  std::atomic_thread_fence(std::memory_order_acquire)
+#   define PaUtil_WriteMemoryBarrier() std::atomic_thread_fence(std::memory_order_release)
 #elif defined(__GNUC__)
     /* GCC >= 4.1 has built-in intrinsics. We'll use those */
 #   if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)

--- a/src/welle-cli/welle-cli.cpp
+++ b/src/welle-cli/welle-cli.cpp
@@ -297,7 +297,9 @@ struct options_t {
     int web_port = -1; // positive value means enable
     list<int> tests;
     string outputcodec = "";
-    string pcm = PCM_DEVICE;
+    /* ALSA PCM device name; only consumed when HAVE_ALSA is defined
+       (PCM_DEVICE itself is not available without ALSA). */
+    string pcm = "default";
 
     RadioReceiverOptions rro;
 };

--- a/welle-io.plist
+++ b/welle-io.plist
@@ -11,10 +11,12 @@
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<string>@PRODUCT_BUNDLE_IDENTIFIER@</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
+	<string>@SHORT_VERSION@</string>
+	<key>CFBundleVersion</key>
 	<string>@SHORT_VERSION@</string>
 	<key>CFBundleSignature</key>
 	<string>@TYPEINFO@</string>
@@ -25,5 +27,7 @@
 This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

The macOS build had stopped working with current Qt versions and GitHub runner images. This PR gets it working again and adds packages that can be downloaded for nightly testing.

CI builds macOS 15 and 26 on both Apple Silicon and Intel. Each job builds and smoke-tests `welle-io.app` and `welle-cli`, bundles the Qt and Homebrew libraries, applies an ad-hoc signature, and creates a ZIP artifact. Pushes to `master` and `next*` can also upload that ZIP to the nightly server when the credentials are available.

The PR also:

- fixes the bundle identifier and version metadata
- moves the deployment commands into `scripts/macos-deploy.sh`, so local builds and CI use the same steps
- replaces the old ring-buffer barriers with atomic read and write indices
- fixes the CLI build on systems without ALSA
- documents the local macOS build and packaging steps

#### How was it tested? How can it be tested by the reviewer?

- `actionlint .github/workflows/macos.yml`
- Local release build of the GUI and CLI
- GUI and CLI smoke tests
- Bundle deployment followed by `codesign --verify --deep --strict`
- ZIP integrity check with `unzip -t`
- Full four-runner CI matrix: https://github.com/rmens/welle.io/actions/runs/32897940602

I also downloaded the Intel artifacts and checked that the executables are x86_64 Mach-O files and that the bundle signature is valid.

#### Any background context you want to provide?

macOS 14 is not in the matrix because its Intel runner is deprecated and unavailable to this fork. The matrix therefore covers macOS 15 and 26 on both architectures.

These are nightly/development packages, so they use an ad-hoc signature. macOS may ask the user to approve the app in Privacy & Security. A release build still needs a Developer ID certificate and Apple notarization but that is outside the scope of this PR.

#### AI usage
OpenAI Codex was used to prepare this patch. I manually de-slopped and optimized it.